### PR TITLE
migrate name to taxadb

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: taxald
+Package: taxadb
 Version: 0.0.0.9000
 Title: Taxonomic Linked Data 
 Description: Creates a local database of many commonly used taxonomic authorities
@@ -42,5 +42,5 @@ Suggests:
     purrr
 Language: en-US
 VignetteBuilder: knitr
-URL: https://github.com/cboettig/taxald
-BugReports: https://github.com/cboettig/taxald/issues
+URL: https://github.com/cboettig/taxadb
+BugReports: https://github.com/cboettig/taxadb/issues

--- a/R/classification.R
+++ b/R/classification.R
@@ -6,7 +6,7 @@
 #'  specified as (`Genus species` or `Genus species epithet`)
 #' @param id alternately users can provide a vector of species ids.
 #'  IDs must be prefixed matching the requested authority.  See `id`
-#'  column returned by most `taxald` functions for examples.
+#'  column returned by most `taxadb` functions for examples.
 #' @inheritParams ids
 #' @return a data.frame with one row for each requested species,
 #'  giving the species id, and column for each of the unique-rank

--- a/R/get_ids.R
+++ b/R/get_ids.R
@@ -11,14 +11,14 @@
 #'   - `prefix` (e.g. `NCBI:9606`), or
 #'   - `uri` (e.g.
 #'   `http://ncbi.nlm.nih.gov/taxonomy/9606`).
-#' @param taxald_db Connection to from `[td_connect]()`.
+#' @param taxadb_db Connection to from `[td_connect]()`.
 #' @param ... additional arguments passed to `ids()`
 #' @details Note that some taxize authorities: `nbn`, `tropicos`, and `eol`,
-#' are not recognized by taxald and will throw an error here. Meanwhile,
-#' taxald recognizes several authorities not known to `[taxize::get_ids()]`.
+#' are not recognized by taxadb and will throw an error here. Meanwhile,
+#' taxadb recognizes several authorities not known to `[taxize::get_ids()]`.
 #' Both include `itis`, `ncbi`, `col`, and `gbif`.
 #'
-#' Like all taxald functions, this function will run
+#' Like all taxadb functions, this function will run
 #' fastest if a local copy of the authority is installed in advance
 #' using `[td_create()]`.
 #' @examples \donttest{
@@ -31,7 +31,7 @@ get_ids <- function(names,
                     db = c("itis", "ncbi", "col", "tpl",
                            "gbif", "fb", "slb", "wd"),
                     format = c("bare", "prefix", "uri"),
-                    taxald_db = td_connect(),
+                    taxadb_db = td_connect(),
                     ...){
   format <- match.arg(format)
   # be compatible with common space delimiters
@@ -39,7 +39,7 @@ get_ids <- function(names,
   df <- ids(name = names,
              authority = db,
              collect = TRUE,
-             db = taxald_db)
+             db = taxadb_db)
 
   if("accepted_id" %in% names(df))
    out <- df %>% pull("accepted_id")

--- a/R/ids.R
+++ b/R/ids.R
@@ -11,7 +11,7 @@
 #' data.frame (default, usually the most convenient), or a reference to
 #' lazy-eval table on disk (useful for very large tables on which we may
 #' first perform subsequent filtering operations.)
-#' @param db a connection to the taxald database. See details.
+#' @param db a connection to the taxadb database. See details.
 #' @return a data.frame with columns of `id`, scientific
 #' `name`, and `rank`, and `accepted_id` (if data includes synonyms)
 #'  and a row for each species name queried.

--- a/R/taxa_tbl.R
+++ b/R/taxa_tbl.R
@@ -1,7 +1,7 @@
 
-#' Return a reference to a given table in the taxald database
+#' Return a reference to a given table in the taxadb database
 #'
-#' @param db a connection to the taxald database. Default will
+#' @param db a connection to the taxadb database. Default will
 #' attempt to connect automatically.
 #' @param schema the table schema on which we want to run the query
 #' @importFrom dplyr tbl
@@ -35,7 +35,7 @@ quick_db <- memoise::memoise(
     # FIXME -- use the same rappdirs location, not tmpfile!
     tmp <- tempfile(fileext = ".tsv.bz2")
     download.file(
-      paste0("https://github.com/cboettig/taxald/",
+      paste0("https://github.com/cboettig/taxadb/",
              "releases/download/v1.0.0/data.2f",
              tbl_name, ".tsv.bz2"),
              tmp)

--- a/R/td_connect.R
+++ b/R/td_connect.R
@@ -1,9 +1,9 @@
-#' Connect to the taxald database
+#' Connect to the taxadb database
 #'
 #' @param dbdir Path to the database.
 #' @return Returns a `src_dbi` connection to the database
 #' @details Primarily useful when a lower-level interface to the
-#' database is required.  Most `taxald` functions will connect
+#' database is required.  Most `taxadb` functions will connect
 #' automatically without the user needing to call this function.
 #' @importFrom DBI dbConnect
 #' @importFrom MonetDBLite MonetDBLite
@@ -13,7 +13,7 @@
 #' db <- connect_db()
 #'
 #' }
-td_connect <- function(dbdir = rappdirs::user_data_dir("taxald")){
+td_connect <- function(dbdir = rappdirs::user_data_dir("taxadb")){
 
   dbname <- file.path(dbdir, "monetdblite")
 
@@ -21,7 +21,7 @@ td_connect <- function(dbdir = rappdirs::user_data_dir("taxald")){
   ## CANNOT Just check if this file exists -- that breaks every connection!
   ## Stop if monetdb is pointing to another location from the same session
 
-  db <- mget("td_db", envir = taxald_cache, ifnotfound = NA)[[1]]
+  db <- mget("td_db", envir = taxadb_cache, ifnotfound = NA)[[1]]
   if (inherits(db, "DBIConnection")) {
     if (DBI::dbIsValid(db)) {
       return(db)
@@ -30,20 +30,20 @@ td_connect <- function(dbdir = rappdirs::user_data_dir("taxald")){
 
   dir.create(dbname, FALSE)
   db <- DBI::dbConnect(MonetDBLite::MonetDBLite(), dbname)
-  assign("td_db", db, envir = taxald_cache)
+  assign("td_db", db, envir = taxadb_cache)
 
   db
 }
 
-td_disconnect <- function(env = taxald_cache){
+td_disconnect <- function(env = taxadb_cache){
   db <- mget("td_db", envir = env, ifnotfound = NA)[[1]]
   if (inherits(db, "DBIConnection")) {
     DBI::dbDisconnect(db)
   }
 }
 
-taxald_cache <- new.env()
-reg.finalizer(taxald_cache, td_disconnect, onexit = TRUE)
+taxadb_cache <- new.env()
+reg.finalizer(taxadb_cache, td_disconnect, onexit = TRUE)
 
 
 ## dyplr automatially drops temporary table on disconnect

--- a/R/td_create.R
+++ b/R/td_create.R
@@ -13,10 +13,10 @@
 #'  a local database upon new release.)
 #' @param dbdir a location on your computer where the database should be installed.
 #'  Defaults to user data directory given by [rappdirs::user_data_dir]().
-#' @param db connection to a database.  By default, taxald will set up its own
+#' @param db connection to a database.  By default, taxadb will set up its own
 #' fast [MonetDBLite::MonetDBLite]() connection.
 #' @details
-#'  Authorities recognized by taxald are:
+#'  Authorities recognized by taxadb are:
 #'  - `itis`
 #'  - `ncbi`
 #'  - `col`
@@ -42,7 +42,7 @@ td_create <- function(authorities = "itis",
                       schema = c("hierarchy", "taxonid", "synonyms"),
                       overwrite = FALSE,
                       lines = 1e6,
-                      dbdir =  rappdirs::user_data_dir("taxald"),
+                      dbdir =  rappdirs::user_data_dir("taxadb"),
                       db = td_connect(dbdir)
                       ){
 
@@ -77,7 +77,7 @@ td_create <- function(authorities = "itis",
 
   if (length(new_files) >= 1L) {
     ## FIXME eventually these should be Zenodo URLs
-    urls <- paste0("https://github.com/cboettig/taxald/",
+    urls <- paste0("https://github.com/cboettig/taxadb/",
                    "releases/download/v1.0.0/",
                    "data", ".2f", new_files)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -3,10 +3,10 @@ output: github_document
 ---
 
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
-[![Travis build status](https://travis-ci.org/cboettig/taxald.svg?branch=master)](https://travis-ci.org/cboettig/taxald)
-[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/cboettig/taxald?branch=master&svg=true)](https://ci.appveyor.com/project/cboettig/taxald)
-[![Coverage status](https://codecov.io/gh/cboettig/taxald/branch/master/graph/badge.svg)](https://codecov.io/github/cboettig/taxald?branch=master)
-[![CRAN status](https://www.r-pkg.org/badges/version/taxald)](https://cran.r-project.org/package=taxald)
+[![Travis build status](https://travis-ci.org/cboettig/taxadb.svg?branch=master)](https://travis-ci.org/cboettig/taxadb)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/cboettig/taxadb?branch=master&svg=true)](https://ci.appveyor.com/project/cboettig/taxadb)
+[![Coverage status](https://codecov.io/gh/cboettig/taxadb/branch/master/graph/badge.svg)](https://codecov.io/github/cboettig/taxadb?branch=master)
+[![CRAN status](https://www.r-pkg.org/badges/version/taxadb)](https://cran.r-project.org/package=taxadb)
 
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -18,11 +18,11 @@ knitr::opts_chunk$set(
 )
 ```
 
-# taxald
+# taxadb
 
-The goal of `taxald` is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records. 
+The goal of `taxadb` is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records. 
 
-Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines.  Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. `taxald` creates a *local* database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.  
+Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines.  Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. `taxadb` creates a *local* database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.  
 
 
 ## Install and initial setup
@@ -30,14 +30,14 @@ Existing approaches to these problems typically rely on web APIs, which can make
 To get started, install the development version directly from GitHub:
 
 ```{r eval=FALSE}
-devtools::install_github("cboettig/taxald")
+devtools::install_github("cboettig/taxadb")
 ```
 
 
-Before we can use most `taxald` functions, we need to do a one-time installation of the database `taxald` uses for almost all commands.  This can take a while to run, but needs only be done once.  The database is installed on your local hard-disk and will persist between R sessions.  By default, the database will be installed in your user's application data directory, as detected by the `rappdirs` package.  (Set a custom location instead using `dbdir` argument.)
+Before we can use most `taxadb` functions, we need to do a one-time installation of the database `taxadb` uses for almost all commands.  This can take a while to run, but needs only be done once.  The database is installed on your local hard-disk and will persist between R sessions.  By default, the database will be installed in your user's application data directory, as detected by the `rappdirs` package.  (Set a custom location instead using `dbdir` argument.)
 
 ```{r }
-library(taxald)
+library(taxadb)
 td_create()
 ```
 
@@ -56,11 +56,16 @@ descendants(name = "Aves", rank = "class")
 
 ## Learn More
 
-### [An introduction to taxald](https://cboettig.github.io/taxald/articles/articles/taxald.html) 
+### [An introduction to taxadb](https://cboettig.github.io/taxadb/articles/articles/taxadb.html) 
 
-The [taxald introduction](https://cboettig.github.io/taxald/articles/articles/taxald.html) 
-provides an overview showing how `taxald` functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.  
+The [taxadb introduction](https://cboettig.github.io/taxadb/articles/articles/taxadb.html) 
+provides an overview showing how `taxadb` functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.  
 
-### [taxald schemas](https://cboettig.github.io/taxald/articles/articles/schema.html)
+### [taxadb schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html)
 
-See the [schemas](https://cboettig.github.io/taxald/articles/articles/schema.html) vignette for an overview of the underlying tables used by `taxald` functions, and more about the different authorities accessed by taxald.  
+See the [schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html) vignette for an overview of the underlying tables used by `taxadb` functions, and more about the different authorities accessed by taxadb.  
+
+
+```{r include=FALSE}
+taxadb:::td_disconnect()
+```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![Travis build
-status](https://travis-ci.org/cboettig/taxald.svg?branch=master)](https://travis-ci.org/cboettig/taxald)
+status](https://travis-ci.org/cboettig/taxadb.svg?branch=master)](https://travis-ci.org/cboettig/taxadb)
 [![AppVeyor build
-status](https://ci.appveyor.com/api/projects/status/github/cboettig/taxald?branch=master&svg=true)](https://ci.appveyor.com/project/cboettig/taxald)
+status](https://ci.appveyor.com/api/projects/status/github/cboettig/taxadb?branch=master&svg=true)](https://ci.appveyor.com/project/cboettig/taxadb)
 [![Coverage
-status](https://codecov.io/gh/cboettig/taxald/branch/master/graph/badge.svg)](https://codecov.io/github/cboettig/taxald?branch=master)
+status](https://codecov.io/gh/cboettig/taxadb/branch/master/graph/badge.svg)](https://codecov.io/github/cboettig/taxadb?branch=master)
 [![CRAN
-status](https://www.r-pkg.org/badges/version/taxald)](https://cran.r-project.org/package=taxald)
+status](https://www.r-pkg.org/badges/version/taxadb)](https://cran.r-project.org/package=taxadb)
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# taxald
+# taxadb
 
-The goal of `taxald` is to provide fast access to taxonomic data and
+The goal of `taxadb` is to provide fast access to taxonomic data and
 manipulations, such as resolving taxonomic names to ids, looking up
 higher classification ranks of given species, or returning a list of all
 species below a given rank. These tasks are particularly common when
@@ -24,7 +24,7 @@ Existing approaches to these problems typically rely on web APIs, which
 can make them impractical for work with large numbers of species or in
 more complex pipelines. Queries and returned formats also differ across
 the different taxonomic authorities, making tasks that query multiple
-authorities particularly complex. `taxald` creates a *local* database of
+authorities particularly complex. `taxadb` creates a *local* database of
 most readily available taxonomic authorities, each of which is
 transformed into consistent, standard, and researcher-friendly tabular
 formats.
@@ -34,11 +34,11 @@ formats.
 To get started, install the development version directly from GitHub:
 
 ``` r
-devtools::install_github("cboettig/taxald")
+devtools::install_github("cboettig/taxadb")
 ```
 
-Before we can use most `taxald` functions, we need to do a one-time
-installation of the database `taxald` uses for almost all commands. This
+Before we can use most `taxadb` functions, we need to do a one-time
+installation of the database `taxadb` uses for almost all commands. This
 can take a while to run, but needs only be done once. The database is
 installed on your local hard-disk and will persist between R sessions.
 By default, the database will be installed in your user’s application
@@ -46,7 +46,7 @@ data directory, as detected by the `rappdirs` package. (Set a custom
 location instead using `dbdir` argument.)
 
 ``` r
-library(taxald)
+library(taxadb)
 td_create()
 #> not overwriting itis_hierarchy
 #> not overwriting itis_taxonid
@@ -87,17 +87,17 @@ descendants(name = "Aves", rank = "class")
 
 ## Learn More
 
-### [An introduction to taxald](https://cboettig.github.io/taxald/articles/articles/taxald.html)
+### [An introduction to taxadb](https://cboettig.github.io/taxadb/articles/articles/taxadb.html)
 
-The [taxald
-introduction](https://cboettig.github.io/taxald/articles/articles/taxald.html)
-provides an overview showing how `taxald` functions can help us
+The [taxadb
+introduction](https://cboettig.github.io/taxadb/articles/articles/taxadb.html)
+provides an overview showing how `taxadb` functions can help us
 synthesize data across a given list of species by resolving synonyms and
 identifiers.
 
-### [taxald schemas](https://cboettig.github.io/taxald/articles/articles/schema.html)
+### [taxadb schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html)
 
 See the
-[schemas](https://cboettig.github.io/taxald/articles/articles/schema.html)
-vignette for an overview of the underlying tables used by `taxald`
-functions, and more about the different authorities accessed by taxald.
+[schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html)
+vignette for an overview of the underlying tables used by `taxadb`
+functions, and more about the different authorities accessed by taxadb.

--- a/data-raw/taxizedb-raw.R
+++ b/data-raw/taxizedb-raw.R
@@ -1,41 +1,50 @@
+## Use taxizedb to download all data from original sources and establish in native database formats
+## Then, use arkdb to extract all tables as tsv.bz2 files
 
-## apt -y install mariadb-client postgresql-client
+## This script requires a postgres database and mariadb database be already set up
+## and available using the user name, password, and connection addresses given below.
+
+## Instead of running this code, cached copies of the extracted databases are avialable
+## as a piggyback from the github repo.  Simply run:
+##     piggyback::pb_download(repo = "cboettig/taxadb")
 
 library(arkdb)
-library(taxizedb) # remotes::install_github("ropensci/taxizedb")
+library(taxizedb)
 
 #### ITIS ###########
 itis_store <- db_download_itis()
-db_load_itis(itis_store, user = "postgres", pwd = "password", host = "postgres") # locale issues
+#db_load_itis(itis_store, user = "postgres", pwd = "password", host = "postgres") # locale issues
 itis_db <- src_itis(user = "postgres", password = "password", host = "postgres")
-ark(itis_db, fs::dir_create("taxizedb/itis"), lines = 1e6L, overwrite = TRUE)
+ark(itis_db, fs::dir_create("taxizedb/itis"), streamable_table = streamable_readr_tsv(), lines = 1e5L)
 
 #### TPL ##############
 tpl <- db_download_tpl()
 db_load_tpl(tpl, user = "postgres", pwd = "password", host = "postgres")
 tpl_db <- src_tpl(user = "postgres", password = "password", host = "postgres")
-ark(tpl_db, fs::dir_create("taxizedb/tpl"), lines = 1e6L, overwrite = TRUE)
+ark(tpl_db, fs::dir_create("taxizedb/tpl"), streamable_table = streamable_readr_tsv(), lines = 1e5L)
 
 ##### NCBI ################
 ncbi_store <- db_download_ncbi()
 db_load_ncbi() ## not needed for ncbi
 ncbi_db <- src_ncbi(ncbi_store)
-ark(ncbi_db, fs::dir_create("taxizedb/ncbi"), lines = 1e6L, overwrite = TRUE)
+ark(ncbi_db, fs::dir_create("taxizedb/ncbi"), streamable_table = streamable_readr_tsv(), lines = 1e5L)
 
 #### GBIF ############
 gbif <- db_download_gbif()
 db_load_gbif()## not needed
 gbif_db <- src_gbif(gbif)
-ark(gbif_db, fs::dir_create("taxizedb/gbif"), lines = 1e6L, overwrite = TRUE)
+ark(gbif_db, fs::dir_create("taxizedb/gbif"), streamable_table = streamable_readr_tsv(), lines = 1e5L)
 
 ### COL ###################
-#options(scipen = 100)
 col <- db_download_col()
-db_load_col(col, host="mariadb", user="root", pwd="password")  ## Slow to rerun
+#db_load_col(col, host="mariadb", user="root", pwd="password")  ## Slow to rerun
 col_db <- src_col(host="mariadb", user="root", password="password")
-ark(col_db, fs::dir_create("taxizedb/col"), lines = 1e6L, overwrite = TRUE)
+ark(col_db, fs::dir_create("taxizedb/col"), streamable_table = streamable_readr_tsv(), lines = 1e5L)
 
 
-## upload
+library(fs)
+library(magrittr)
+library(piggyback)
+## ENSURE GitHub PAT is available for uploading -- developers only.
 fs::dir_ls("taxizedb", type = "file", recursive = TRUE) %>%
-piggyback::pb_upload(repo = "cboettig/taxadb")
+  piggyback::pb_upload()

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>License • taxald</title>
+<title>License • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -35,8 +37,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -59,8 +60,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -86,13 +87,13 @@
       <a href="articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="articles/articles/schema.html">Database schema for taxald</a>
+      <a href="articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="articles/articles/taxald.html">taxald overview</a>
+      <a href="articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="articles/intro.html">Quickstart for taxald</a>
+      <a href="articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -100,7 +101,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -135,8 +136,9 @@ COPYRIGHT HOLDER: Carl Boettiger
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>MIT License • taxald</title>
+<title>MIT License • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -35,8 +37,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -59,8 +60,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -86,13 +87,13 @@
       <a href="articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="articles/articles/schema.html">Database schema for taxald</a>
+      <a href="articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="articles/articles/taxald.html">taxald overview</a>
+      <a href="articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="articles/intro.html">Quickstart for taxald</a>
+      <a href="articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -100,7 +101,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -139,8 +140,9 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/articles/articles/crosswalk.html
+++ b/docs/articles/articles/crosswalk.html
@@ -5,14 +5,15 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Crosswalking The Authorities • taxald</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
+<title>Crosswalking The Authorities • taxadb</title>
+<link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
 <script src="../../pkgdown.js"></script><meta property="og:title" content="Crosswalking The Authorities">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -29,8 +30,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -56,20 +57,20 @@
       <a href="../../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../../articles/articles/taxald.html">taxald overview</a>
+      <a href="../../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../../articles/intro.html">Quickstart for taxald</a>
+      <a href="../../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -89,109 +90,109 @@
       <h1>Crosswalking The Authorities</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2018-12-11</h4>
+            <h4 class="date">2018-12-21</h4>
       
-      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxald/blob/master/vignettes/articles/crosswalk.Rmd"><code>vignettes/articles/crosswalk.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxadb/blob/master/vignettes/articles/crosswalk.Rmd"><code>vignettes/articles/crosswalk.Rmd</code></a></small>
       <div class="hidden name"><code>crosswalk.Rmd</code></div>
 
     </div>
 
     
     
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(taxald)
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(dplyr)
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(tidyr)</code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw">library</span>(taxadb)</a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw">library</span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw">library</span>(tidyr)</a></code></pre></div>
 <p>Work in progress – the mismatches of <code>itis</code>, <code>col</code> and <code>wd</code> here illustrate the complexity of name matching. Some names resolve multiple times. Some authorities (ITIS) recognize certain synonyms that they still haven’t mapped to accepted id.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">fish &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"fb"</span>) <span class="op">%&gt;%</span><span class="st">  </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="dt">fb =</span> id, species) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/compute.html">collect</a></span>() 
-species &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(fish, species)
-
-itis &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"itis"</span>)
-wd &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"wd"</span>)
-col &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"col"</span>)
-
-## Note each of these authorities all return more rows than we had in the input table!
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/lapply">sapply</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">fb =</span> fish, <span class="dt">itis =</span> itis, <span class="dt">wd =</span> wd, <span class="dt">col =</span> col), <span class="cf">function</span>(x) <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/length">length</a></span>(x[[<span class="dv">1</span>]]))
-<span class="co">#&gt;    fb  itis    wd   col </span>
-<span class="co">#&gt; 33124 33153 33127 36351</span></code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa &lt;-<span class="st"> </span>fish <span class="op">%&gt;%</span>
-
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="co">#itis = get_ids(species, "itis"),</span>
-         <span class="dt">ncbi =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"ncbi"</span>),
-         <span class="co">#col = get_ids(species, "col"),</span>
-         <span class="dt">gbif =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"gbif"</span>),
-         <span class="co">#wd = get_ids(species, "wd"),</span>
-         <span class="dt">tpl =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"tpl"</span>),
-        <span class="co"># fb = get_ids(species, "fb"),</span>
-         <span class="dt">slb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"slb"</span>)) </code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dbl</a></span>(<span class="cf">function</span>(x) <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/sum">sum</a></span>(<span class="op">!</span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(x)))
-<span class="co">#&gt;    fb  ncbi  gbif   tpl   slb </span>
-<span class="co">#&gt; 33124   287 17378     3     0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">fish &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"fb"</span>) <span class="op">%&gt;%</span><span class="st">  </span></a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="dt">fb =</span> id, species) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb2-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/compute.html">collect</a></span>() </a>
+<a class="sourceLine" id="cb2-4" data-line-number="4">species &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(fish, species)</a>
+<a class="sourceLine" id="cb2-5" data-line-number="5"></a>
+<a class="sourceLine" id="cb2-6" data-line-number="6">itis &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"itis"</span>)</a>
+<a class="sourceLine" id="cb2-7" data-line-number="7">wd &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"wd"</span>)</a>
+<a class="sourceLine" id="cb2-8" data-line-number="8">col &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"col"</span>)</a>
+<a class="sourceLine" id="cb2-9" data-line-number="9"></a>
+<a class="sourceLine" id="cb2-10" data-line-number="10"><span class="co">## Note each of these authorities all return more rows than we had in the input table!</span></a>
+<a class="sourceLine" id="cb2-11" data-line-number="11"><span class="kw">sapply</span>(<span class="kw">list</span>(<span class="dt">fb =</span> fish, <span class="dt">itis =</span> itis, <span class="dt">wd =</span> wd, <span class="dt">col =</span> col), <span class="cf">function</span>(x) <span class="kw">length</span>(x[[<span class="dv">1</span>]]))</a>
+<a class="sourceLine" id="cb2-12" data-line-number="12"><span class="co">#&gt;    fb  itis    wd   col </span></a>
+<a class="sourceLine" id="cb2-13" data-line-number="13"><span class="co">#&gt; 33124 33153 33127 36351</span></a></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">my_taxa &lt;-<span class="st"> </span>fish <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb3-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="co">#itis = get_ids(species, "itis"),</span></a>
+<a class="sourceLine" id="cb3-4" data-line-number="4">         <span class="dt">ncbi =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"ncbi"</span>),</a>
+<a class="sourceLine" id="cb3-5" data-line-number="5">         <span class="co">#col = get_ids(species, "col"),</span></a>
+<a class="sourceLine" id="cb3-6" data-line-number="6">         <span class="dt">gbif =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"gbif"</span>),</a>
+<a class="sourceLine" id="cb3-7" data-line-number="7">         <span class="co">#wd = get_ids(species, "wd"),</span></a>
+<a class="sourceLine" id="cb3-8" data-line-number="8">         <span class="dt">tpl =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"tpl"</span>),</a>
+<a class="sourceLine" id="cb3-9" data-line-number="9">        <span class="co"># fb = get_ids(species, "fb"),</span></a>
+<a class="sourceLine" id="cb3-10" data-line-number="10">         <span class="dt">slb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"slb"</span>)) </a></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">my_taxa <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb4-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb4-3" data-line-number="3"><span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dbl</a></span>(<span class="cf">function</span>(x) <span class="kw">sum</span>(<span class="op">!</span><span class="kw">is.na</span>(x)))</a>
+<a class="sourceLine" id="cb4-4" data-line-number="4"><span class="co">#&gt;    fb  ncbi  gbif   tpl   slb </span></a>
+<a class="sourceLine" id="cb4-5" data-line-number="5"><span class="co">#&gt; 33124   287 17378     3     0</span></a></code></pre></div>
 <p>Looks like three plants have matching scientific names to some of our fish:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">dup &lt;-<span class="st"> </span>fish <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(species) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(<span class="dt">authority =</span> <span class="st">"tpl"</span>) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(id))
-dup
-<span class="co">#&gt; # A tibble: 3 x 3</span>
-<span class="co">#&gt;   id         name                  rank   </span>
-<span class="co">#&gt;   &lt;chr&gt;      &lt;chr&gt;                 &lt;chr&gt;  </span>
-<span class="co">#&gt; 1 TPL:57374  Centropogon australis species</span>
-<span class="co">#&gt; 2 TPL:236238 Orestias elegans      species</span>
-<span class="co">#&gt; 3 TPL:300628 Rondeletia bicolor    species</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">dup &lt;-<span class="st"> </span>fish <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(species) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(<span class="dt">authority =</span> <span class="st">"tpl"</span>) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span><span class="kw">is.na</span>(id))</a>
+<a class="sourceLine" id="cb5-2" data-line-number="2">dup</a>
+<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="co">#&gt; # A tibble: 3 x 3</span></a>
+<a class="sourceLine" id="cb5-4" data-line-number="4"><span class="co">#&gt;   id         name                  rank   </span></a>
+<a class="sourceLine" id="cb5-5" data-line-number="5"><span class="co">#&gt;   &lt;chr&gt;      &lt;chr&gt;                 &lt;chr&gt;  </span></a>
+<a class="sourceLine" id="cb5-6" data-line-number="6"><span class="co">#&gt; 1 TPL:57374  Centropogon australis species</span></a>
+<a class="sourceLine" id="cb5-7" data-line-number="7"><span class="co">#&gt; 2 TPL:300628 Rondeletia bicolor    species</span></a>
+<a class="sourceLine" id="cb5-8" data-line-number="8"><span class="co">#&gt; 3 TPL:236238 Orestias elegans      species</span></a></code></pre></div>
 <p>This also probably explains why <code>col</code> and <code>wd</code> are returning the wrong-length matches:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">species &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(fish, species)
-
-col_fb &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"col"</span>) 
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/dim">dim</a></span>(col_fb)[<span class="dv">1</span>] <span class="op">-</span><span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/length">length</a></span>(species)
-<span class="co">#&gt; [1] 3227</span>
-
-wd_fb &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"wd"</span>) 
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/dim">dim</a></span>(wd_fb)[<span class="dv">1</span>] <span class="op">-</span><span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/length">length</a></span>(species)
-<span class="co">#&gt; [1] 3</span></code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">
-<span class="co">#col_hierarchy &lt;- classification(id = col_fb$id) %&gt;% filter(kingdom == "Animalia") </span>
-
-<span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"col"</span>, <span class="st">"hierarchy"</span>) <span class="op">%&gt;%</span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(kingdom <span class="op">==</span><span class="st"> "Animalia"</span>) <span class="op">%&gt;%</span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/join.html">semi_join</a></span>(<span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(col_fb, id), <span class="dt">copy =</span> <span class="ot">TRUE</span>) <span class="op">%&gt;%</span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(id, species) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/compute.html">collect</a></span>()
-<span class="co">#&gt; Joining, by = "id"</span>
-<span class="co">#&gt; # A tibble: 32,923 x 2</span>
-<span class="co">#&gt;    id           species     </span>
-<span class="co">#&gt;    &lt;chr&gt;        &lt;chr&gt;       </span>
-<span class="co">#&gt;  1 COL:21092068 immaculata  </span>
-<span class="co">#&gt;  2 COL:21092241 felis       </span>
-<span class="co">#&gt;  3 COL:21092375 bentincki   </span>
-<span class="co">#&gt;  4 COL:21092504 rubrofuscus </span>
-<span class="co">#&gt;  5 COL:21092598 acuminatus  </span>
-<span class="co">#&gt;  6 COL:21092599 sadina      </span>
-<span class="co">#&gt;  7 COL:21092690 grandicassis</span>
-<span class="co">#&gt;  8 COL:21092694 ansorgii    </span>
-<span class="co">#&gt;  9 COL:21092789 lineolata   </span>
-<span class="co">#&gt; 10 COL:21093101 melanotheron</span>
-<span class="co">#&gt; # ... with 32,913 more rows</span></code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">has_match &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species, <span class="op">-</span>fb) <span class="op">%&gt;%</span>
-<span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dfc</a></span>(<span class="cf">function</span>(x) <span class="op">!</span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(x)) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/colSums">rowSums</a></span>() <span class="op">&gt;</span><span class="st"> </span><span class="dv">0</span>
-
-my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span>has_match)
-<span class="co">#&gt; # A tibble: 15,746 x 6</span>
-<span class="co">#&gt;    fb       species                     ncbi  gbif  tpl   slb  </span>
-<span class="co">#&gt;    &lt;chr&gt;    &lt;chr&gt;                       &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span>
-<span class="co">#&gt;  1 FB:46263 Melanochromis lepidiadaptes &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  2 FB:46264 Aspidoras poecilus          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  3 FB:46265 Aspidoras raimundi          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  4 FB:46266 Aspidoras rochai            &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  5 FB:46267 Aspidoras spilotus          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  6 FB:46268 Aspidoras virgulatus        &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  7 FB:46271 Chilodus fritillus          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  8 FB:46273 Mastacembelus traversi      &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  9 FB:46274 Rasbora laticlavia          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt; 10 FB:46277 Pontinus helena             &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt; # ... with 15,736 more rows</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">species &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(fish, species)</a>
+<a class="sourceLine" id="cb6-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb6-3" data-line-number="3">col_fb &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"col"</span>) </a>
+<a class="sourceLine" id="cb6-4" data-line-number="4"><span class="kw">dim</span>(col_fb)[<span class="dv">1</span>] <span class="op">-</span><span class="st"> </span><span class="kw">length</span>(species)</a>
+<a class="sourceLine" id="cb6-5" data-line-number="5"><span class="co">#&gt; [1] 3227</span></a>
+<a class="sourceLine" id="cb6-6" data-line-number="6"></a>
+<a class="sourceLine" id="cb6-7" data-line-number="7">wd_fb &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/ids.html">ids</a></span>(species, <span class="st">"wd"</span>) </a>
+<a class="sourceLine" id="cb6-8" data-line-number="8"><span class="kw">dim</span>(wd_fb)[<span class="dv">1</span>] <span class="op">-</span><span class="st"> </span><span class="kw">length</span>(species)</a>
+<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; [1] 3</span></a></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1"></a>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="co">#col_hierarchy &lt;- classification(id = col_fb$id) %&gt;% filter(kingdom == "Animalia") </span></a>
+<a class="sourceLine" id="cb7-3" data-line-number="3"></a>
+<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"col"</span>, <span class="st">"hierarchy"</span>) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-5" data-line-number="5"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(kingdom <span class="op">==</span><span class="st"> "Animalia"</span>) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-6" data-line-number="6"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/join.html">semi_join</a></span>(<span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(col_fb, id), <span class="dt">copy =</span> <span class="ot">TRUE</span>) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-7" data-line-number="7"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(id, species) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb7-8" data-line-number="8"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/compute.html">collect</a></span>()</a>
+<a class="sourceLine" id="cb7-9" data-line-number="9"><span class="co">#&gt; Joining, by = "id"</span></a>
+<a class="sourceLine" id="cb7-10" data-line-number="10"><span class="co">#&gt; # A tibble: 32,923 x 2</span></a>
+<a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt;    id           species     </span></a>
+<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt;    &lt;chr&gt;        &lt;chr&gt;       </span></a>
+<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt;  1 COL:21092068 immaculata  </span></a>
+<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt;  2 COL:21092241 felis       </span></a>
+<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt;  3 COL:21092375 bentincki   </span></a>
+<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt;  4 COL:21092504 rubrofuscus </span></a>
+<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt;  5 COL:21092598 acuminatus  </span></a>
+<a class="sourceLine" id="cb7-18" data-line-number="18"><span class="co">#&gt;  6 COL:21092599 sadina      </span></a>
+<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt;  7 COL:21092690 grandicassis</span></a>
+<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt;  8 COL:21092694 ansorgii    </span></a>
+<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt;  9 COL:21092789 lineolata   </span></a>
+<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; 10 COL:21093101 melanotheron</span></a>
+<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; # ... with 32,913 more rows</span></a></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">has_match &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb8-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species, <span class="op">-</span>fb) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb8-3" data-line-number="3"><span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dfc</a></span>(<span class="cf">function</span>(x) <span class="op">!</span><span class="kw">is.na</span>(x)) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb8-4" data-line-number="4"><span class="st">  </span><span class="kw">rowSums</span>() <span class="op">&gt;</span><span class="st"> </span><span class="dv">0</span></a>
+<a class="sourceLine" id="cb8-5" data-line-number="5"></a>
+<a class="sourceLine" id="cb8-6" data-line-number="6">my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span>has_match)</a>
+<a class="sourceLine" id="cb8-7" data-line-number="7"><span class="co">#&gt; # A tibble: 15,608 x 6</span></a>
+<a class="sourceLine" id="cb8-8" data-line-number="8"><span class="co">#&gt;    fb    species                  ncbi  gbif  tpl   slb  </span></a>
+<a class="sourceLine" id="cb8-9" data-line-number="9"><span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt;                    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span></a>
+<a class="sourceLine" id="cb8-10" data-line-number="10"><span class="co">#&gt;  1 FB:4  Engraulis ringens        &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-11" data-line-number="11"><span class="co">#&gt;  2 FB:5  Orthopristis chrysoptera &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-12" data-line-number="12"><span class="co">#&gt;  3 FB:9  Abalistes stellaris      &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-13" data-line-number="13"><span class="co">#&gt;  4 FB:10 Alectis indica           &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-14" data-line-number="14"><span class="co">#&gt;  5 FB:12 Cephalopholis cruentata  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-15" data-line-number="15"><span class="co">#&gt;  6 FB:14 Epinephelus adscensionis &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-16" data-line-number="16"><span class="co">#&gt;  7 FB:15 Epinephelus guttatus     &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-17" data-line-number="17"><span class="co">#&gt;  8 FB:18 Epinephelus striatus     &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-18" data-line-number="18"><span class="co">#&gt;  9 FB:19 Balistes vetula          &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-19" data-line-number="19"><span class="co">#&gt; 10 FB:20 Argentina sphyraena      &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-20" data-line-number="20"><span class="co">#&gt; # ... with 15,598 more rows</span></a></code></pre></div>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -205,8 +206,9 @@ my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw">
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
 </div>
 

--- a/docs/articles/articles/schema.html
+++ b/docs/articles/articles/schema.html
@@ -5,14 +5,15 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Database schema for taxald • taxald</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
-<script src="../../pkgdown.js"></script><meta property="og:title" content="Database schema for taxald">
+<title>Database schema for taxadb • taxadb</title>
+<link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
+<script src="../../pkgdown.js"></script><meta property="og:title" content="Database schema for taxadb">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -29,8 +30,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -56,20 +57,20 @@
       <a href="../../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../../articles/articles/taxald.html">taxald overview</a>
+      <a href="../../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../../articles/intro.html">Quickstart for taxald</a>
+      <a href="../../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -86,19 +87,19 @@
       </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
-      <h1>Database schema for taxald</h1>
+      <h1>Database schema for taxadb</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2018-12-11</h4>
+            <h4 class="date">2018-12-21</h4>
       
-      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxald/blob/master/vignettes/articles/schema.Rmd"><code>vignettes/articles/schema.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxadb/blob/master/vignettes/articles/schema.Rmd"><code>vignettes/articles/schema.Rmd</code></a></small>
       <div class="hidden name"><code>schema.Rmd</code></div>
 
     </div>
 
     
     
-<p><code>taxald</code> relies on a set of pre-assembled tables following a set of standardized schema layouts outlined below. The database dumps provided by authorities supported in <code>taxald</code> at this time are:</p>
+<p><code>taxadb</code> relies on a set of pre-assembled tables following a set of standardized schema layouts outlined below. The database dumps provided by authorities supported in <code>taxadb</code> at this time are:</p>
 <ul>
 <li>
 <code>itis</code>: <a href="https://www.itis.gov/">The Integrated Taxonomic Information System</a>
@@ -125,11 +126,11 @@
 <code>wd</code>: <a href="https://wikidata.org">WikiData</a>
 </li>
 </ul>
-<p>These authorities provide taxonomic data in a wide range of database formats using a wide range of data layouts (schemas), not all of which are particularly easy to use or interpret (e.g. hierarchies are often but not always specified in <code>taxon_id,parent_id</code> pairs.) To make it faster and easier to work across these authorities, <code>taxald</code> defines a common set of table schemas outlined below that are particularly suited for efficient computation of common tasks. <code>taxald</code> pre-processes and publicly archives compressed, flat tables corresponding to each of these schema for each of these authorities.</p>
-<p>Using the schema defined below, most common operations can be expressed in terms of very standard operations, such as simple filtering joins in SQL. to implement these, <code>taxald</code> imports the compressed flat files into a local, column-oriented database, <a href=""><code>MonetDBLite</code></a>, which can be installed entirely as an R package with no additional server setup required. This provides a persistant store, and ensures that operations can be performed on disk since the taxonomic tables considered here are frequently too large to store in active memory. The columnar structure enables blazingly fast joins. Once the database is created, <code>taxald</code> simply wraps a set of user-friendly R functions around common <code>SQL</code> queries, implemented in the popular <code>dplyr</code> syntax. By default, <code>taxald</code> will always collect the results of these queries to return familiar, in-memory objects to the R user. Optional arguments allow more direct access the database queries.</p>
-<p>This vignette summarizes the table schema defined by <code>taxald</code>. Pre-processing of the original database dumps from each authority into the format described here can be found in the corresponding scripts in <code>data-raw</code> directory of the R package source code.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(taxald)
-<span class="kw"><a href="../../reference/td_create.html">td_create</a></span>(<span class="st">"all"</span>)</code></pre></div>
+<p>These authorities provide taxonomic data in a wide range of database formats using a wide range of data layouts (schemas), not all of which are particularly easy to use or interpret (e.g. hierarchies are often but not always specified in <code>taxon_id,parent_id</code> pairs.) To make it faster and easier to work across these authorities, <code>taxadb</code> defines a common set of table schemas outlined below that are particularly suited for efficient computation of common tasks. <code>taxadb</code> pre-processes and publicly archives compressed, flat tables corresponding to each of these schema for each of these authorities.</p>
+<p>Using the schema defined below, most common operations can be expressed in terms of very standard operations, such as simple filtering joins in SQL. to implement these, <code>taxadb</code> imports the compressed flat files into a local, column-oriented database, <a href=""><code>MonetDBLite</code></a>, which can be installed entirely as an R package with no additional server setup required. This provides a persistant store, and ensures that operations can be performed on disk since the taxonomic tables considered here are frequently too large to store in active memory. The columnar structure enables blazingly fast joins. Once the database is created, <code>taxadb</code> simply wraps a set of user-friendly R functions around common <code>SQL</code> queries, implemented in the popular <code>dplyr</code> syntax. By default, <code>taxadb</code> will always collect the results of these queries to return familiar, in-memory objects to the R user. Optional arguments allow more direct access the database queries.</p>
+<p>This vignette summarizes the table schema defined by <code>taxadb</code>. Pre-processing of the original database dumps from each authority into the format described here can be found in the corresponding scripts in <code>data-raw</code> directory of the R package source code.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw">library</span>(taxadb)</a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="../../reference/td_create.html">td_create</a></span>(<span class="st">"all"</span>)</a></code></pre></div>
 <div id="taxonid-schema" class="section level2">
 <h2 class="hasAnchor">
 <a href="#taxonid-schema" class="anchor"></a>taxonid schema</h2>
@@ -145,23 +146,23 @@
 <code>accepted_id</code> the accepted id; (for synonyms, otherwise identical to the <code>id</code> for accepted names)</li>
 </ul>
 <p>Some authorities may report additional optional columns, such as the <code>update_date</code>, <code>name_type</code>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"itis"</span>, <span class="st">"taxonid"</span>)
-<span class="co">#&gt; # Source:   table&lt;itis_taxonid&gt; [?? x 6]</span>
-<span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span>
-<span class="co">#&gt;    id         accepted_id update_date name               rank   name_usage</span>
-<span class="co">#&gt;    &lt;chr&gt;      &lt;chr&gt;       &lt;chr&gt;       &lt;chr&gt;              &lt;chr&gt;  &lt;chr&gt;     </span>
-<span class="co">#&gt;  1 ITIS:100   ITIS:50     2015-03-02  Spirillum beijeri… speci… synonym   </span>
-<span class="co">#&gt;  2 ITIS:1000… ITIS:724028 2007-06-14  Hypogastrura jond… speci… synonym   </span>
-<span class="co">#&gt;  3 ITIS:1000… ITIS:724028 2007-06-14  Achorutes jondavi  speci… synonym   </span>
-<span class="co">#&gt;  4 ITIS:1000… ITIS:804239 2016-04-01  Niponius itoi      speci… synonym   </span>
-<span class="co">#&gt;  5 ITIS:1000… ITIS:804276 2016-04-01  Chlamydopsis rufo… speci… synonym   </span>
-<span class="co">#&gt;  6 ITIS:1000… ITIS:804277 2016-04-01  Chlamydopsis mast… speci… synonym   </span>
-<span class="co">#&gt;  7 ITIS:1000… ITIS:804279 2016-04-01  Chlamydopsis darw… speci… synonym   </span>
-<span class="co">#&gt;  8 ITIS:1000… ITIS:804309 2016-04-01  Chlamydopsis exca… speci… synonym   </span>
-<span class="co">#&gt;  9 ITIS:1000… ITIS:804309 2016-04-01  Chlamydopsis punc… speci… synonym   </span>
-<span class="co">#&gt; 10 ITIS:1000… ITIS:724073 2007-06-14  Hypogastrura pseu… speci… synonym   </span>
-<span class="co">#&gt; # ... with more rows</span></code></pre></div>
-<p>Note that <code>taxald</code> tables report all identifiers using authority prefixes. Certain authorities only provide taxanomic identifiers to species names (rank is always species). Currently this includes <code>gbif</code>, <code>fb</code>, <code>slb</code>. <code>ncbi</code>, <code>col</code> and <code>itis</code> provide taxonomic identifers to scientific names at any rank.</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"itis"</span>, <span class="st">"taxonid"</span>)</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="co">#&gt; # Source:   table&lt;itis_taxonid&gt; [?? x 6]</span></a>
+<a class="sourceLine" id="cb2-3" data-line-number="3"><span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span></a>
+<a class="sourceLine" id="cb2-4" data-line-number="4"><span class="co">#&gt;    id         accepted_id update_date name               rank   name_usage</span></a>
+<a class="sourceLine" id="cb2-5" data-line-number="5"><span class="co">#&gt;    &lt;chr&gt;      &lt;chr&gt;       &lt;chr&gt;       &lt;chr&gt;              &lt;chr&gt;  &lt;chr&gt;     </span></a>
+<a class="sourceLine" id="cb2-6" data-line-number="6"><span class="co">#&gt;  1 ITIS:100   ITIS:50     2015-03-02  Spirillum beijeri… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-7" data-line-number="7"><span class="co">#&gt;  2 ITIS:1000… ITIS:724028 2007-06-14  Hypogastrura jond… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co">#&gt;  3 ITIS:1000… ITIS:724028 2007-06-14  Achorutes jondavi  speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co">#&gt;  4 ITIS:1000… ITIS:804239 2016-04-01  Niponius itoi      speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-10" data-line-number="10"><span class="co">#&gt;  5 ITIS:1000… ITIS:804276 2016-04-01  Chlamydopsis rufo… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-11" data-line-number="11"><span class="co">#&gt;  6 ITIS:1000… ITIS:804277 2016-04-01  Chlamydopsis mast… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-12" data-line-number="12"><span class="co">#&gt;  7 ITIS:1000… ITIS:804279 2016-04-01  Chlamydopsis darw… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-13" data-line-number="13"><span class="co">#&gt;  8 ITIS:1000… ITIS:804309 2016-04-01  Chlamydopsis exca… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-14" data-line-number="14"><span class="co">#&gt;  9 ITIS:1000… ITIS:804309 2016-04-01  Chlamydopsis punc… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-15" data-line-number="15"><span class="co">#&gt; 10 ITIS:1000… ITIS:724073 2007-06-14  Hypogastrura pseu… speci… synonym   </span></a>
+<a class="sourceLine" id="cb2-16" data-line-number="16"><span class="co">#&gt; # ... with more rows</span></a></code></pre></div>
+<p>Note that <code>taxadb</code> tables report all identifiers using authority prefixes. Certain authorities only provide taxanomic identifiers to species names (rank is always species). Currently this includes <code>gbif</code>, <code>fb</code>, <code>slb</code>. <code>ncbi</code>, <code>col</code> and <code>itis</code> provide taxonomic identifers to scientific names at any rank.</p>
 </div>
 <div id="hierarchy-table" class="section level2">
 <h2 class="hasAnchor">
@@ -169,23 +170,23 @@
 <p>Any valid rank is a column, and a taxon <code>id</code> is a unique key.</p>
 <p>First column is named <code>id</code>, all subsequent columns are corresponding rank names. Note that this wide format does not support unnamed rank levels, which are common in certain classifications such as NCBI. Additional issues arise in some databases (e.g. also in NCBI) where a rank name is duplicated.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"col"</span>, <span class="st">"hierarchy"</span>)
-<span class="co">#&gt; # Source:   table&lt;col_hierarchy&gt; [?? x 11]</span>
-<span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span>
-<span class="co">#&gt;    id    kingdom phylum class order superfamily family genus subgenus</span>
-<span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;       &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;   </span>
-<span class="co">#&gt;  1 COL:2 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Tasm… &lt;NA&gt;    </span>
-<span class="co">#&gt;  2 COL:6 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Tasm… &lt;NA&gt;    </span>
-<span class="co">#&gt;  3 COL:8 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Torr… &lt;NA&gt;    </span>
-<span class="co">#&gt;  4 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span>
-<span class="co">#&gt;  5 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span>
-<span class="co">#&gt;  6 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span>
-<span class="co">#&gt;  7 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span>
-<span class="co">#&gt;  8 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Anog… &lt;NA&gt;    </span>
-<span class="co">#&gt;  9 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Braz… &lt;NA&gt;    </span>
-<span class="co">#&gt; 10 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Cary… &lt;NA&gt;    </span>
-<span class="co">#&gt; # ... with more rows, and 2 more variables: species &lt;chr&gt;,</span>
-<span class="co">#&gt; #   infraspecies &lt;chr&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"col"</span>, <span class="st">"hierarchy"</span>)</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"><span class="co">#&gt; # Source:   table&lt;col_hierarchy&gt; [?? x 11]</span></a>
+<a class="sourceLine" id="cb3-3" data-line-number="3"><span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span></a>
+<a class="sourceLine" id="cb3-4" data-line-number="4"><span class="co">#&gt;    id    kingdom phylum class order superfamily family genus subgenus</span></a>
+<a class="sourceLine" id="cb3-5" data-line-number="5"><span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;       &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;   </span></a>
+<a class="sourceLine" id="cb3-6" data-line-number="6"><span class="co">#&gt;  1 COL:2 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Tasm… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-7" data-line-number="7"><span class="co">#&gt;  2 COL:6 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Tasm… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-8" data-line-number="8"><span class="co">#&gt;  3 COL:8 Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Torr… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-9" data-line-number="9"><span class="co">#&gt;  4 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-10" data-line-number="10"><span class="co">#&gt;  5 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-11" data-line-number="11"><span class="co">#&gt;  6 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-12" data-line-number="12"><span class="co">#&gt;  7 COL:… Animal… Mollu… Gast… Styl… Rhytidoidea Rhyti… Vict… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-13" data-line-number="13"><span class="co">#&gt;  8 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Anog… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-14" data-line-number="14"><span class="co">#&gt;  9 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Braz… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-15" data-line-number="15"><span class="co">#&gt; 10 COL:… Animal… Mollu… Gast… Styl… Acavoidea   Caryo… Cary… &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb3-16" data-line-number="16"><span class="co">#&gt; # ... with more rows, and 2 more variables: species &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-17" data-line-number="17"><span class="co">#&gt; #   infraspecies &lt;chr&gt;</span></a></code></pre></div>
 </div>
 <div id="synonyms-table" class="section level2">
 <h2 class="hasAnchor">
@@ -212,27 +213,27 @@
 <code>name_type</code>: the type of name given in <code>name</code>, e.g. <code>synonym</code>, <code>misspelling</code>, etc.</li>
 </ul>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"gbif"</span>, <span class="st">"synonyms"</span>)
-<span class="co">#&gt; # Source:   table&lt;gbif_synonyms&gt; [?? x 5]</span>
-<span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span>
-<span class="co">#&gt;    id        accepted_name     rank    name              name_type</span>
-<span class="co">#&gt;    &lt;chr&gt;     &lt;chr&gt;             &lt;chr&gt;   &lt;chr&gt;             &lt;chr&gt;    </span>
-<span class="co">#&gt;  1 GBIF:0    incertae sedis    kingdom incertae sedis    doubtful </span>
-<span class="co">#&gt;  2 GBIF:104  Prasinophyta      phylum  Prasinophyta      synonym  </span>
-<span class="co">#&gt;  3 GBIF:191  Bryopsidophyceae  class   Bryopsidophyceae  synonym  </span>
-<span class="co">#&gt;  4 GBIF:287  Fragilariophyceae class   Fragilariophyceae synonym  </span>
-<span class="co">#&gt;  5 GBIF:835  Eutreptiales      order   Eutreptiales      synonym  </span>
-<span class="co">#&gt;  6 GBIF:1345 Chlorococcales    order   Chlorococcales    synonym  </span>
-<span class="co">#&gt;  7 GBIF:1902 Krohnitelldae     family  Krohnitelldae     synonym  </span>
-<span class="co">#&gt;  8 GBIF:1909 Chlorangiaceae    family  Chlorangiaceae    synonym  </span>
-<span class="co">#&gt;  9 GBIF:1964 Haploposthiidae   family  Haploposthiidae   synonym  </span>
-<span class="co">#&gt; 10 GBIF:1976 Questidae         family  Questidae         synonym  </span>
-<span class="co">#&gt; # ... with more rows</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"gbif"</span>, <span class="st">"synonyms"</span>)</a>
+<a class="sourceLine" id="cb4-2" data-line-number="2"><span class="co">#&gt; # Source:   table&lt;gbif_synonyms&gt; [?? x 5]</span></a>
+<a class="sourceLine" id="cb4-3" data-line-number="3"><span class="co">#&gt; # Database: MonetDBEmbeddedConnection</span></a>
+<a class="sourceLine" id="cb4-4" data-line-number="4"><span class="co">#&gt;    id        accepted_name     rank    name              name_type</span></a>
+<a class="sourceLine" id="cb4-5" data-line-number="5"><span class="co">#&gt;    &lt;chr&gt;     &lt;chr&gt;             &lt;chr&gt;   &lt;chr&gt;             &lt;chr&gt;    </span></a>
+<a class="sourceLine" id="cb4-6" data-line-number="6"><span class="co">#&gt;  1 GBIF:0    incertae sedis    kingdom incertae sedis    doubtful </span></a>
+<a class="sourceLine" id="cb4-7" data-line-number="7"><span class="co">#&gt;  2 GBIF:104  Prasinophyta      phylum  Prasinophyta      synonym  </span></a>
+<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt;  3 GBIF:191  Bryopsidophyceae  class   Bryopsidophyceae  synonym  </span></a>
+<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt;  4 GBIF:287  Fragilariophyceae class   Fragilariophyceae synonym  </span></a>
+<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt;  5 GBIF:835  Eutreptiales      order   Eutreptiales      synonym  </span></a>
+<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt;  6 GBIF:1345 Chlorococcales    order   Chlorococcales    synonym  </span></a>
+<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt;  7 GBIF:1902 Krohnitelldae     family  Krohnitelldae     synonym  </span></a>
+<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt;  8 GBIF:1909 Chlorangiaceae    family  Chlorangiaceae    synonym  </span></a>
+<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt;  9 GBIF:1964 Haploposthiidae   family  Haploposthiidae   synonym  </span></a>
+<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 10 GBIF:1976 Questidae         family  Questidae         synonym  </span></a>
+<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; # ... with more rows</span></a></code></pre></div>
 </div>
 <div id="common-names" class="section level2">
 <h2 class="hasAnchor">
 <a href="#common-names" class="anchor"></a>Common names</h2>
-<p>Common names are avialable from several authorities, but tidy tables for <code>taxald</code> have not yet been implemented. Common names tables are expected to follow the following schema:</p>
+<p>Common names are avialable from several authorities, but tidy tables for <code>taxadb</code> have not yet been implemented. Common names tables are expected to follow the following schema:</p>
 <ul>
 <li>
 <code>id</code> The taxonomic identifier for the species (or possibly other rank)</li>
@@ -271,9 +272,9 @@
 <tbody></tbody>
 </table>
 <p>(Most databases do not define <code>rank_id</code>, e.g. ids corresponding to the ranks themselves)</p>
-<p>These tables are considerably larger and longer than other formats, which can make them slow to query. Note that for each taxonomic name, <code>id</code> and the corresponding <code>name</code>, and <code>rank</code> of the <code>id</code> are repeated across the full path hierarchy. This format is not installed and not used by functions of <code>taxald</code> at this time.</p>
+<p>These tables are considerably larger and longer than other formats, which can make them slow to query. Note that for each taxonomic name, <code>id</code> and the corresponding <code>name</code>, and <code>rank</code> of the <code>id</code> are repeated across the full path hierarchy. This format is not installed and not used by functions of <code>taxadb</code> at this time.</p>
 <p>A fundamental advantage of this format is that it can be defined identically for every table, meaning that all authorities could be combined into a single table using the long format. both the <code>taxonid</code> and <code>hierarchy</code> formats can be derived directly from this format, and this format can represent information such as unnamed or duplicate ranks that cannot be represented in the <code>hierarchy</code> format.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"itis"</span>, <span class="st">"long"</span>, <span class="ot">NULL</span>)</code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="kw"><a href="../../reference/taxa_tbl.html">taxa_tbl</a></span>(<span class="st">"itis"</span>, <span class="st">"long"</span>, <span class="ot">NULL</span>)</a></code></pre></div>
 </div>
 <div id="conventions" class="section level2">
 <h2 class="hasAnchor">
@@ -311,8 +312,9 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
 </div>
 

--- a/docs/articles/articles/taxald.html
+++ b/docs/articles/articles/taxald.html
@@ -5,14 +5,15 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>taxald overview • taxald</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
-<script src="../../pkgdown.js"></script><meta property="og:title" content="taxald overview">
+<title>taxadb overview • taxadb</title>
+<link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../../pkgdown.css" rel="stylesheet">
+<script src="../../pkgdown.js"></script><meta property="og:title" content="taxadb overview">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -29,8 +30,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -56,20 +57,20 @@
       <a href="../../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../../articles/articles/taxald.html">taxald overview</a>
+      <a href="../../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../../articles/intro.html">Quickstart for taxald</a>
+      <a href="../../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -86,189 +87,189 @@
       </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
-      <h1>taxald overview</h1>
+      <h1>taxadb overview</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2018-12-11</h4>
+            <h4 class="date">2018-12-21</h4>
       
-      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxald/blob/master/vignettes/articles/taxald.Rmd"><code>vignettes/articles/taxald.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxadb/blob/master/vignettes/articles/taxald.Rmd"><code>vignettes/articles/taxald.Rmd</code></a></small>
       <div class="hidden name"><code>taxald.Rmd</code></div>
 
     </div>
 
     
     
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(taxald)
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(dplyr)
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(tidyr)</code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw">library</span>(taxadb)</a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw">library</span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw">library</span>(tidyr)</a></code></pre></div>
 <div id="introduction-the-problem-of-name-matching" class="section level1">
 <h1 class="hasAnchor">
 <a href="#introduction-the-problem-of-name-matching" class="anchor"></a>Introduction: the problem of name matching</h1>
 <p>We frequently want to combine different data sources using species names. Perhaps we have one table which gives us occurrance information for a given list of species, and another table that contains trait information for species, and maybe a third source that provides a phylogenetic tree. If our system of scientific species names was perfect, we could simply do a “table join” using species name as the joining <code>key</code>, and all would be well.</p>
 <p>Unfortunately, as anyone who has attempted this kind of exercise over more than a handful of species has discovered, this often works for most but very rarely for all of the species names involved. There are several reasons this process runs into problems.</p>
 <p><strong>Synonyms</strong>. One of the most common problems is the existence of synonyms: different names or different spellings of a given scientific name. While this could include definite miss-spellings, for there are many species for which authorities can differ in the preferred name – essentially, two or more different names correspond to the same species, and should be treated as such in our species join.</p>
-<p>For instance, we consider the 233 primate species names used in the <code>geiger</code> package <code>primates</code> data. To avoid installing that dependency-heavy package, a copy of these names has been cached in <code>taxald</code> and can be loaded as follows:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">ex &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"extdata"</span>, <span class="st">"primates.tsv.bz2"</span>, <span class="dt">package =</span> <span class="st">"taxald"</span>, <span class="dt">mustWork =</span> <span class="ot">TRUE</span>)
-primates &lt;-<span class="st"> </span>readr<span class="op">::</span><span class="kw"><a href="https://readr.tidyverse.org/reference/read_delim.html">read_tsv</a></span>(ex)
-<span class="co">#&gt; Parsed with column specification:</span>
-<span class="co">#&gt; cols(</span>
-<span class="co">#&gt;   species = col_character()</span>
-<span class="co">#&gt; )</span>
-primates
-<span class="co">#&gt; # A tibble: 233 x 1</span>
-<span class="co">#&gt;    species                    </span>
-<span class="co">#&gt;    &lt;chr&gt;                      </span>
-<span class="co">#&gt;  1 Allenopithecus nigroviridis</span>
-<span class="co">#&gt;  2 Allocebus trichotis        </span>
-<span class="co">#&gt;  3 Alouatta belzebul          </span>
-<span class="co">#&gt;  4 Alouatta caraya            </span>
-<span class="co">#&gt;  5 Alouatta coibensis         </span>
-<span class="co">#&gt;  6 Alouatta fusca             </span>
-<span class="co">#&gt;  7 Alouatta palliata          </span>
-<span class="co">#&gt;  8 Alouatta pigra             </span>
-<span class="co">#&gt;  9 Alouatta sara              </span>
-<span class="co">#&gt; 10 Alouatta seniculus         </span>
-<span class="co">#&gt; # ... with 223 more rows</span></code></pre></div>
+<p>For instance, we consider the 233 primate species names used in the <code>geiger</code> package <code>primates</code> data. To avoid installing that dependency-heavy package, a copy of these names has been cached in <code>taxadb</code> and can be loaded as follows:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">ex &lt;-<span class="st"> </span><span class="kw">system.file</span>(<span class="st">"extdata"</span>, <span class="st">"primates.tsv.bz2"</span>, <span class="dt">package =</span> <span class="st">"taxadb"</span>, <span class="dt">mustWork =</span> <span class="ot">TRUE</span>)</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2">primates &lt;-<span class="st"> </span>readr<span class="op">::</span><span class="kw"><a href="https://readr.tidyverse.org/reference/read_delim.html">read_tsv</a></span>(ex)</a>
+<a class="sourceLine" id="cb2-3" data-line-number="3"><span class="co">#&gt; Parsed with column specification:</span></a>
+<a class="sourceLine" id="cb2-4" data-line-number="4"><span class="co">#&gt; cols(</span></a>
+<a class="sourceLine" id="cb2-5" data-line-number="5"><span class="co">#&gt;   species = col_character()</span></a>
+<a class="sourceLine" id="cb2-6" data-line-number="6"><span class="co">#&gt; )</span></a>
+<a class="sourceLine" id="cb2-7" data-line-number="7">primates</a>
+<a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co">#&gt; # A tibble: 233 x 1</span></a>
+<a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co">#&gt;    species                    </span></a>
+<a class="sourceLine" id="cb2-10" data-line-number="10"><span class="co">#&gt;    &lt;chr&gt;                      </span></a>
+<a class="sourceLine" id="cb2-11" data-line-number="11"><span class="co">#&gt;  1 Allenopithecus nigroviridis</span></a>
+<a class="sourceLine" id="cb2-12" data-line-number="12"><span class="co">#&gt;  2 Allocebus trichotis        </span></a>
+<a class="sourceLine" id="cb2-13" data-line-number="13"><span class="co">#&gt;  3 Alouatta belzebul          </span></a>
+<a class="sourceLine" id="cb2-14" data-line-number="14"><span class="co">#&gt;  4 Alouatta caraya            </span></a>
+<a class="sourceLine" id="cb2-15" data-line-number="15"><span class="co">#&gt;  5 Alouatta coibensis         </span></a>
+<a class="sourceLine" id="cb2-16" data-line-number="16"><span class="co">#&gt;  6 Alouatta fusca             </span></a>
+<a class="sourceLine" id="cb2-17" data-line-number="17"><span class="co">#&gt;  7 Alouatta palliata          </span></a>
+<a class="sourceLine" id="cb2-18" data-line-number="18"><span class="co">#&gt;  8 Alouatta pigra             </span></a>
+<a class="sourceLine" id="cb2-19" data-line-number="19"><span class="co">#&gt;  9 Alouatta sara              </span></a>
+<a class="sourceLine" id="cb2-20" data-line-number="20"><span class="co">#&gt; 10 Alouatta seniculus         </span></a>
+<a class="sourceLine" id="cb2-21" data-line-number="21"><span class="co">#&gt; # ... with 223 more rows</span></a></code></pre></div>
 <p>Our goal will be to associate each name with a definitive taxonomic ID of an existing naming authority. This will allow us to merge on IDs directly, rather than names. By mapping both recognized names and synonyms to the same corresponding taxonomic ID, we can be sure that we can join the relevant data correctly.</p>
 <div id="setup" class="section level2">
 <h2 class="hasAnchor">
 <a href="#setup" class="anchor"></a>Setup</h2>
-<p>To get started, we’ll install all the data sources available to <code>taxald</code> into a local database. This may take a while, particularly over a slow internet connection, but it needs to be done only once. The downloaded size of all data is around 3 GB. Once this task completes, our subsequent operations should all be quite fast.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/td_create.html">td_create</a></span>(<span class="dt">authorities =</span> <span class="st">"all"</span>)</code></pre></div>
+<p>To get started, we’ll install all the data sources available to <code>taxadb</code> into a local database. This may take a while, particularly over a slow internet connection, but it needs to be done only once. The downloaded size of all data is around 3 GB. Once this task completes, our subsequent operations should all be quite fast.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="../../reference/td_create.html">td_create</a></span>(<span class="dt">authorities =</span> <span class="st">"all"</span>)</a></code></pre></div>
 </div>
 <div id="resolving-names" class="section level2">
 <h2 class="hasAnchor">
 <a href="#resolving-names" class="anchor"></a>Resolving names</h2>
 <p>Match a list of 233 species names against a naming authority:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa &lt;-<span class="st"> </span>primates <span class="op">%&gt;%</span><span class="st">  </span><span class="co"># 233 taxa</span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="dt">id =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="dt">format =</span> <span class="st">"prefix"</span>)) </code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(id))
-<span class="co">#&gt; # A tibble: 3 x 2</span>
-<span class="co">#&gt;   species            id   </span>
-<span class="co">#&gt;   &lt;chr&gt;              &lt;chr&gt;</span>
-<span class="co">#&gt; 1 Aotus brumbacki    &lt;NA&gt; </span>
-<span class="co">#&gt; 2 Aotus hershkovitzi &lt;NA&gt; </span>
-<span class="co">#&gt; 3 Varecia variegata  &lt;NA&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">my_taxa &lt;-<span class="st"> </span>primates <span class="op">%&gt;%</span><span class="st">  </span><span class="co"># 233 taxa</span></a>
+<a class="sourceLine" id="cb4-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="dt">id =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="dt">format =</span> <span class="st">"prefix"</span>)) </a></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw">is.na</span>(id))</a>
+<a class="sourceLine" id="cb5-2" data-line-number="2"><span class="co">#&gt; # A tibble: 3 x 2</span></a>
+<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="co">#&gt;   species            id   </span></a>
+<a class="sourceLine" id="cb5-4" data-line-number="4"><span class="co">#&gt;   &lt;chr&gt;              &lt;chr&gt;</span></a>
+<a class="sourceLine" id="cb5-5" data-line-number="5"><span class="co">#&gt; 1 Aotus brumbacki    &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb5-6" data-line-number="6"><span class="co">#&gt; 2 Aotus hershkovitzi &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb5-7" data-line-number="7"><span class="co">#&gt; 3 Varecia variegata  &lt;NA&gt;</span></a></code></pre></div>
 <p>Only 3 species are missing ids, so we have managed to resolve 230 of the 233 species. Not bad! Actually,two of these do appear in ITIS records, but map to no accepted name according to ITIS:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">unmatched &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(id)) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(species) 
-<span class="kw"><a href="../../reference/synonyms.html">synonyms</a></span>(unmatched)
-<span class="co">#&gt; # A tibble: 3 x 6</span>
-<span class="co">#&gt;   name            accepted_name   id         synonym_id rank   update_date</span>
-<span class="co">#&gt;   &lt;chr&gt;           &lt;chr&gt;           &lt;chr&gt;      &lt;chr&gt;      &lt;chr&gt;  &lt;chr&gt;      </span>
-<span class="co">#&gt; 1 Aotus hershkov… Aotus lemurinus ITIS:5729… ITIS:5729… speci… 2014-06-26 </span>
-<span class="co">#&gt; 2 Aotus brumbacki &lt;NA&gt;            &lt;NA&gt;       &lt;NA&gt;       &lt;NA&gt;   &lt;NA&gt;       </span>
-<span class="co">#&gt; 3 Varecia varieg… &lt;NA&gt;            &lt;NA&gt;       &lt;NA&gt;       &lt;NA&gt;   &lt;NA&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">unmatched &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw">is.na</span>(id)) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(species) </a>
+<a class="sourceLine" id="cb6-2" data-line-number="2"><span class="kw"><a href="../../reference/synonyms.html">synonyms</a></span>(unmatched)</a>
+<a class="sourceLine" id="cb6-3" data-line-number="3"><span class="co">#&gt; # A tibble: 3 x 6</span></a>
+<a class="sourceLine" id="cb6-4" data-line-number="4"><span class="co">#&gt;   name            accepted_name   id         synonym_id rank   update_date</span></a>
+<a class="sourceLine" id="cb6-5" data-line-number="5"><span class="co">#&gt;   &lt;chr&gt;           &lt;chr&gt;           &lt;chr&gt;      &lt;chr&gt;      &lt;chr&gt;  &lt;chr&gt;      </span></a>
+<a class="sourceLine" id="cb6-6" data-line-number="6"><span class="co">#&gt; 1 Aotus hershkov… Aotus lemurinus ITIS:5729… ITIS:5729… speci… 2014-06-26 </span></a>
+<a class="sourceLine" id="cb6-7" data-line-number="7"><span class="co">#&gt; 2 Aotus brumbacki &lt;NA&gt;            &lt;NA&gt;       &lt;NA&gt;       &lt;NA&gt;   &lt;NA&gt;       </span></a>
+<a class="sourceLine" id="cb6-8" data-line-number="8"><span class="co">#&gt; 3 Varecia varieg… &lt;NA&gt;            &lt;NA&gt;       &lt;NA&gt;       &lt;NA&gt;   &lt;NA&gt;</span></a></code></pre></div>
 <p>Under the hood, <code>get_ids</code> checks the names against synonyms known to the authority as well. If we only looke for direct matches, we would have faired far worse.</p>
 <p>Mimicking <code>taxize</code> function of the same name <code>get_ids</code> is returning just a vector of <code>ids</code>, which is useful for operations such as <code>mutate</code> above. However, it is often convenient to return the full table of matched names. Here we can see that many of the names we have matched against are actually synonyms, and that <code>get_ids</code> has been able to resolve them into accepted ids.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/ids.html">ids</a></span>(primates<span class="op">$</span>species)
-<span class="co">#&gt; # A tibble: 233 x 6</span>
-<span class="co">#&gt;    id         accepted_id  update_date name              rank   name_usage</span>
-<span class="co">#&gt;    &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;       &lt;chr&gt;             &lt;chr&gt;  &lt;chr&gt;     </span>
-<span class="co">#&gt;  1 ITIS:5728… ITIS:944041  2014-06-26  Microcebus coque… speci… synonym   </span>
-<span class="co">#&gt;  2 ITIS:5728… ITIS:944072  2014-06-26  Hapalemur simus   speci… synonym   </span>
-<span class="co">#&gt;  3 ITIS:5728… ITIS:944100  2014-06-26  Galago alleni     speci… synonym   </span>
-<span class="co">#&gt;  4 ITIS:5729… ITIS:1025177 2017-03-30  Galagoides zanzi… speci… synonym   </span>
-<span class="co">#&gt;  5 ITIS:5729… ITIS:945103  2014-06-26  Tarsius bancanus  speci… synonym   </span>
-<span class="co">#&gt;  6 ITIS:5729… ITIS:944117  2014-06-26  Tarsius dianae    speci… synonym   </span>
-<span class="co">#&gt;  7 ITIS:5729… ITIS:944115  2014-06-26  Tarsius spectrum  speci… synonym   </span>
-<span class="co">#&gt;  8 ITIS:5729… ITIS:945107  2014-06-26  Tarsius syrichta  speci… synonym   </span>
-<span class="co">#&gt;  9 ITIS:5729… ITIS:944125  2014-06-26  Callithrix argen… speci… synonym   </span>
-<span class="co">#&gt; 10 ITIS:5729… ITIS:944138  2014-06-26  Callithrix humer… speci… synonym   </span>
-<span class="co">#&gt; # ... with 223 more rows</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1"><span class="kw"><a href="../../reference/ids.html">ids</a></span>(primates<span class="op">$</span>species)</a>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="co">#&gt; # A tibble: 233 x 6</span></a>
+<a class="sourceLine" id="cb7-3" data-line-number="3"><span class="co">#&gt;    id         accepted_id  update_date name              rank   name_usage</span></a>
+<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="co">#&gt;    &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;       &lt;chr&gt;             &lt;chr&gt;  &lt;chr&gt;     </span></a>
+<a class="sourceLine" id="cb7-5" data-line-number="5"><span class="co">#&gt;  1 ITIS:5728… ITIS:944041  2014-06-26  Microcebus coque… speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-6" data-line-number="6"><span class="co">#&gt;  2 ITIS:5728… ITIS:944072  2014-06-26  Hapalemur simus   speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-7" data-line-number="7"><span class="co">#&gt;  3 ITIS:5728… ITIS:944100  2014-06-26  Galago alleni     speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-8" data-line-number="8"><span class="co">#&gt;  4 ITIS:5729… ITIS:1025177 2017-03-30  Galagoides zanzi… speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-9" data-line-number="9"><span class="co">#&gt;  5 ITIS:5729… ITIS:945103  2014-06-26  Tarsius bancanus  speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-10" data-line-number="10"><span class="co">#&gt;  6 ITIS:5729… ITIS:944117  2014-06-26  Tarsius dianae    speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt;  7 ITIS:5729… ITIS:944115  2014-06-26  Tarsius spectrum  speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt;  8 ITIS:5729… ITIS:945107  2014-06-26  Tarsius syrichta  speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt;  9 ITIS:5729… ITIS:944125  2014-06-26  Callithrix argen… speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; 10 ITIS:5729… ITIS:944138  2014-06-26  Callithrix humer… speci… synonym   </span></a>
+<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; # ... with 223 more rows</span></a></code></pre></div>
 <p>Note that <code>name</code> is the name we provided (species names in this case, but it they do not have to be). Because <code>synonyms-check</code> is <code>TRUE</code> by default, we get a list of accepted names recognized (by ITIS in this case, our default authority).</p>
 <p>We aren’t stuck with ITIS though, we can work with other naming authorities as well:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa &lt;-<span class="st"> </span>primates <span class="op">%&gt;%</span><span class="st">  </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="dt">itis =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"itis"</span>),
-         <span class="dt">ncbi =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"ncbi"</span>),
-         <span class="dt">col =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"col"</span>),
-         <span class="dt">gbif =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"gbif"</span>),
-         <span class="dt">wd =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"wd"</span>),
-         <span class="dt">tpl =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"tpl"</span>),
-         <span class="dt">fb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"fb"</span>),
-         <span class="dt">slb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"slb"</span>)) 
-my_taxa
-<span class="co">#&gt; # A tibble: 233 x 9</span>
-<span class="co">#&gt;    species           itis   ncbi   col    gbif   wd      tpl   fb    slb  </span>
-<span class="co">#&gt;    &lt;chr&gt;             &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;   &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span>
-<span class="co">#&gt;  1 Allenopithecus n… 944041 9472   21940… 24363… Q15978… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  2 Allocebus tricho… 944072 9542   21940… 24363… Q35158… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  3 Alouatta belzebul 944100 9557   21940… 24363… Q10647… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  4 Alouatta caraya   10251… 9579   21940… 24364… Q41267… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  5 Alouatta coibens… 945103 9593   21941… 24364… Q21970… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  6 Alouatta fusca    944117 9600   21941… 24364… Q22113… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  7 Alouatta palliata 944115 13515  21940… 24364… Q21963… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  8 Alouatta pigra    945107 30602  21940… 24364… Q21948… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt;  9 Alouatta sara     944125 222416 21940… 24364… Q21948… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt; 10 Alouatta senicul… 944138 9598   21940… 24364… Q713841 &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span>
-<span class="co">#&gt; # ... with 223 more rows</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">my_taxa &lt;-<span class="st"> </span>primates <span class="op">%&gt;%</span><span class="st">  </span></a>
+<a class="sourceLine" id="cb8-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="dt">itis =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"itis"</span>),</a>
+<a class="sourceLine" id="cb8-3" data-line-number="3">         <span class="dt">ncbi =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"ncbi"</span>),</a>
+<a class="sourceLine" id="cb8-4" data-line-number="4">         <span class="dt">col =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"col"</span>),</a>
+<a class="sourceLine" id="cb8-5" data-line-number="5">         <span class="dt">gbif =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"gbif"</span>),</a>
+<a class="sourceLine" id="cb8-6" data-line-number="6">         <span class="dt">wd =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"wd"</span>),</a>
+<a class="sourceLine" id="cb8-7" data-line-number="7">         <span class="dt">tpl =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"tpl"</span>),</a>
+<a class="sourceLine" id="cb8-8" data-line-number="8">         <span class="dt">fb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"fb"</span>),</a>
+<a class="sourceLine" id="cb8-9" data-line-number="9">         <span class="dt">slb =</span> <span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(species, <span class="st">"slb"</span>)) </a>
+<a class="sourceLine" id="cb8-10" data-line-number="10">my_taxa</a>
+<a class="sourceLine" id="cb8-11" data-line-number="11"><span class="co">#&gt; # A tibble: 233 x 9</span></a>
+<a class="sourceLine" id="cb8-12" data-line-number="12"><span class="co">#&gt;    species           itis   ncbi   col    gbif   wd      tpl   fb    slb  </span></a>
+<a class="sourceLine" id="cb8-13" data-line-number="13"><span class="co">#&gt;    &lt;chr&gt;             &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;  &lt;chr&gt;   &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span></a>
+<a class="sourceLine" id="cb8-14" data-line-number="14"><span class="co">#&gt;  1 Allenopithecus n… 944041 9472   21940… 24363… Q15978… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-15" data-line-number="15"><span class="co">#&gt;  2 Allocebus tricho… 944072 9542   21940… 24363… Q35158… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-16" data-line-number="16"><span class="co">#&gt;  3 Alouatta belzebul 944100 9557   21940… 24363… Q10647… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-17" data-line-number="17"><span class="co">#&gt;  4 Alouatta caraya   10251… 9579   21940… 24364… Q41267… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-18" data-line-number="18"><span class="co">#&gt;  5 Alouatta coibens… 945103 9593   21941… 24364… Q21970… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-19" data-line-number="19"><span class="co">#&gt;  6 Alouatta fusca    944117 9600   21941… 24364… Q22113… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-20" data-line-number="20"><span class="co">#&gt;  7 Alouatta palliata 944115 13515  21940… 24364… Q21963… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-21" data-line-number="21"><span class="co">#&gt;  8 Alouatta pigra    945107 30602  21940… 24364… Q21948… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-22" data-line-number="22"><span class="co">#&gt;  9 Alouatta sara     944125 222416 21940… 24364… Q21948… &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-23" data-line-number="23"><span class="co">#&gt; 10 Alouatta senicul… 944138 9598   21940… 24364… Q713841 &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt; </span></a>
+<a class="sourceLine" id="cb8-24" data-line-number="24"><span class="co">#&gt; # ... with 223 more rows</span></a></code></pre></div>
 <p>Can any single authority resolve all species names?</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">my_taxa <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dbl</a></span>(<span class="cf">function</span>(x) <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/sum">sum</a></span>(<span class="op">!</span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(x)))
-<span class="co">#&gt; itis ncbi  col gbif   wd  tpl   fb  slb </span>
-<span class="co">#&gt;  230   90  219   92  209    0    0    0</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">my_taxa <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb9-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb9-3" data-line-number="3"><span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dbl</a></span>(<span class="cf">function</span>(x) <span class="kw">sum</span>(<span class="op">!</span><span class="kw">is.na</span>(x)))</a>
+<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; itis ncbi  col gbif   wd  tpl   fb  slb </span></a>
+<a class="sourceLine" id="cb9-5" data-line-number="5"><span class="co">#&gt;  230   90  219   92  209    0    0    0</span></a></code></pre></div>
 <p>Looks like <code>itis</code> has the most matches with 230. (Of course taxon-specific authorities like The Plant List, FishBase, and SeaLifeBase contain no primates).</p>
 <p>We can also ask: do any species have no match in any authority?</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">has_match &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span>
-<span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dfc</a></span>(<span class="cf">function</span>(x) <span class="op">!</span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/NA">is.na</a></span>(x)) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/colSums">rowSums</a></span>() <span class="op">&gt;</span><span class="st"> </span><span class="dv">0</span>
-
-my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span>has_match)
-<span class="co">#&gt; # A tibble: 1 x 9</span>
-<span class="co">#&gt;   species           itis  ncbi  col   gbif  wd    tpl   fb    slb  </span>
-<span class="co">#&gt;   &lt;chr&gt;             &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span>
-<span class="co">#&gt; 1 Varecia variegata &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">has_match &lt;-<span class="st"> </span>my_taxa <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb10-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>species) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb10-3" data-line-number="3"><span class="st">  </span>purrr<span class="op">::</span><span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_dfc</a></span>(<span class="cf">function</span>(x) <span class="op">!</span><span class="kw">is.na</span>(x)) <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb10-4" data-line-number="4"><span class="st">  </span><span class="kw">rowSums</span>() <span class="op">&gt;</span><span class="st"> </span><span class="dv">0</span></a>
+<a class="sourceLine" id="cb10-5" data-line-number="5"></a>
+<a class="sourceLine" id="cb10-6" data-line-number="6">my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="op">!</span>has_match)</a>
+<a class="sourceLine" id="cb10-7" data-line-number="7"><span class="co">#&gt; # A tibble: 1 x 9</span></a>
+<a class="sourceLine" id="cb10-8" data-line-number="8"><span class="co">#&gt;   species           itis  ncbi  col   gbif  wd    tpl   fb    slb  </span></a>
+<a class="sourceLine" id="cb10-9" data-line-number="9"><span class="co">#&gt;   &lt;chr&gt;             &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;</span></a>
+<a class="sourceLine" id="cb10-10" data-line-number="10"><span class="co">#&gt; 1 Varecia variegata &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;  &lt;NA&gt;</span></a></code></pre></div>
 <p>One species still fails to resolve under any authority. A web search does resolve this as a misspelling, to <code>Leontopithecus chrysomelas</code>, but not one that is recongized automatically by the ITIS known synonyms.</p>
 </div>
 <div id="hierarchy" class="section level2">
 <h2 class="hasAnchor">
 <a href="#hierarchy" class="anchor"></a>Hierarchy</h2>
 <p>Once we have resolved our ids, we can also get full classification information. This example uses the default authority, ITIS:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">primate_ids &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(primates<span class="op">$</span>species, <span class="dt">format =</span> <span class="st">"prefix"</span>)
-<span class="kw"><a href="../../reference/classification.html">classification</a></span>(<span class="dt">id =</span> primate_ids)
-<span class="co">#&gt; Joining, by = "id"</span>
-<span class="co">#&gt; # A tibble: 233 x 26</span>
-<span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span>
-<span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span>
-<span class="co">#&gt;  1 ITIS… Mamm… Homin… Homo  Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  2 ITIS… Mamm… Cebid… Saim… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  3 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  4 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  5 ITIS… Mamm… Cerco… Chlo… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  6 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  7 ITIS… Mamm… Cheir… Allo… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt;  8 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt;  9 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt; 10 ITIS… Mamm… Cheir… Micr… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt; # ... with 223 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span>
-<span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">primate_ids &lt;-<span class="st"> </span><span class="kw"><a href="../../reference/get_ids.html">get_ids</a></span>(primates<span class="op">$</span>species, <span class="dt">format =</span> <span class="st">"prefix"</span>)</a>
+<a class="sourceLine" id="cb11-2" data-line-number="2"><span class="kw"><a href="../../reference/classification.html">classification</a></span>(<span class="dt">id =</span> primate_ids)</a>
+<a class="sourceLine" id="cb11-3" data-line-number="3"><span class="co">#&gt; Joining, by = "id"</span></a>
+<a class="sourceLine" id="cb11-4" data-line-number="4"><span class="co">#&gt; # A tibble: 233 x 26</span></a>
+<a class="sourceLine" id="cb11-5" data-line-number="5"><span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span></a>
+<a class="sourceLine" id="cb11-6" data-line-number="6"><span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span></a>
+<a class="sourceLine" id="cb11-7" data-line-number="7"><span class="co">#&gt;  1 ITIS… Mamm… Homin… Homo  Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-8" data-line-number="8"><span class="co">#&gt;  2 ITIS… Mamm… Cebid… Saim… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-9" data-line-number="9"><span class="co">#&gt;  3 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-10" data-line-number="10"><span class="co">#&gt;  4 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-11" data-line-number="11"><span class="co">#&gt;  5 ITIS… Mamm… Cerco… Chlo… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-12" data-line-number="12"><span class="co">#&gt;  6 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-13" data-line-number="13"><span class="co">#&gt;  7 ITIS… Mamm… Cheir… Allo… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-14" data-line-number="14"><span class="co">#&gt;  8 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-15" data-line-number="15"><span class="co">#&gt;  9 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-16" data-line-number="16"><span class="co">#&gt; 10 ITIS… Mamm… Cheir… Micr… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb11-17" data-line-number="17"><span class="co">#&gt; # ... with 223 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb11-18" data-line-number="18"><span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb11-19" data-line-number="19"><span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb11-20" data-line-number="20"><span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb11-21" data-line-number="21"><span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb11-22" data-line-number="22"><span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></a></code></pre></div>
 <p>the <code>classification</code> function can work on species names directly, but this will not resolve syonyms to identifiers first. As a result, only the 180 already recognized species names can be resolved in this case:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../../reference/classification.html">classification</a></span>(<span class="dt">species =</span> primates<span class="op">$</span>species)
-<span class="co">#&gt; Joining, by = "species"</span>
-<span class="co">#&gt; # A tibble: 233 x 26</span>
-<span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span>
-<span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span>
-<span class="co">#&gt;  1 ITIS… Mamm… Homin… Homo  Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  2 ITIS… Mamm… Cebid… Saim… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  3 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  4 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  5 ITIS… Mamm… Cerco… Chlo… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  6 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span>
-<span class="co">#&gt;  7 ITIS… Mamm… Cheir… Allo… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt;  8 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt;  9 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt; 10 ITIS… Mamm… Cheir… Micr… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span>
-<span class="co">#&gt; # ... with 223 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span>
-<span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1"><span class="kw"><a href="../../reference/classification.html">classification</a></span>(<span class="dt">species =</span> primates<span class="op">$</span>species)</a>
+<a class="sourceLine" id="cb12-2" data-line-number="2"><span class="co">#&gt; Joining, by = "species"</span></a>
+<a class="sourceLine" id="cb12-3" data-line-number="3"><span class="co">#&gt; # A tibble: 233 x 26</span></a>
+<a class="sourceLine" id="cb12-4" data-line-number="4"><span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span></a>
+<a class="sourceLine" id="cb12-5" data-line-number="5"><span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span></a>
+<a class="sourceLine" id="cb12-6" data-line-number="6"><span class="co">#&gt;  1 ITIS… Mamm… Homin… Homo  Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-7" data-line-number="7"><span class="co">#&gt;  2 ITIS… Mamm… Cebid… Saim… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-8" data-line-number="8"><span class="co">#&gt;  3 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-9" data-line-number="9"><span class="co">#&gt;  4 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-10" data-line-number="10"><span class="co">#&gt;  5 ITIS… Mamm… Cerco… Chlo… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-11" data-line-number="11"><span class="co">#&gt;  6 ITIS… Mamm… Cerco… Maca… Eutheria   Deuterostom… Simiiform… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-12" data-line-number="12"><span class="co">#&gt;  7 ITIS… Mamm… Cheir… Allo… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-13" data-line-number="13"><span class="co">#&gt;  8 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-14" data-line-number="14"><span class="co">#&gt;  9 ITIS… Mamm… Cheir… Chei… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-15" data-line-number="15"><span class="co">#&gt; 10 ITIS… Mamm… Cheir… Micr… Eutheria   Deuterostom… Lemurifor… Gnathostom…</span></a>
+<a class="sourceLine" id="cb12-16" data-line-number="16"><span class="co">#&gt; # ... with 223 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb12-17" data-line-number="17"><span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb12-18" data-line-number="18"><span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb12-19" data-line-number="19"><span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb12-20" data-line-number="20"><span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb12-21" data-line-number="21"><span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></a></code></pre></div>
 </div>
 </div>
   </div>
@@ -297,8 +298,9 @@ my_taxa <span class="op">%&gt;%</span><span class="st"> </span><span class="kw">
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
 </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Articles • taxald</title>
+<title>Articles • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -35,8 +37,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -59,8 +60,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -86,13 +87,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -100,7 +101,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -126,9 +127,9 @@
 
       <ul>
         <li><a href="articles/crosswalk.html">Crosswalking The Authorities</a></li>
-        <li><a href="articles/schema.html">Database schema for taxald</a></li>
-        <li><a href="articles/taxald.html">taxald overview</a></li>
-        <li><a href="intro.html">Quickstart for taxald</a></li>
+        <li><a href="articles/schema.html">Database schema for taxadb</a></li>
+        <li><a href="articles/taxald.html">taxadb overview</a></li>
+        <li><a href="intro.html">Quickstart for taxadb</a></li>
       </ul>
     </div>
   </div>
@@ -140,8 +141,9 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/articles/intro.html
+++ b/docs/articles/intro.html
@@ -5,14 +5,15 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Quickstart for taxald • taxald</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
-<script src="../pkgdown.js"></script><meta property="og:title" content="Quickstart for taxald">
+<title>Quickstart for taxadb • taxadb</title>
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
+<script src="../pkgdown.js"></script><meta property="og:title" content="Quickstart for taxadb">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -29,8 +30,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -56,20 +57,20 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -86,28 +87,28 @@
       </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
-      <h1>Quickstart for taxald</h1>
+      <h1>Quickstart for taxadb</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2018-12-11</h4>
+            <h4 class="date">2018-12-21</h4>
       
-      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxald/blob/master/vignettes/intro.Rmd"><code>vignettes/intro.Rmd</code></a></small>
+      <small class="dont-index">Source: <a href="https://github.com/cboettig/taxadb/blob/master/vignettes/intro.Rmd"><code>vignettes/intro.Rmd</code></a></small>
       <div class="hidden name"><code>intro.Rmd</code></div>
 
     </div>
 
     
     
-<p>The goal of <code>taxald</code> is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records.</p>
-<p>Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines. Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. <code>taxald</code> creates a <em>local</em> database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.</p>
+<p>The goal of <code>taxadb</code> is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records.</p>
+<p>Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines. Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. <code>taxadb</code> creates a <em>local</em> database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.</p>
 <div id="install-and-initial-setup" class="section level2">
 <h2 class="hasAnchor">
 <a href="#install-and-initial-setup" class="anchor"></a>Install and initial setup</h2>
 <p>To get started, install the development version directly from GitHub:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">devtools<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"cboettig/taxald"</span>)</code></pre></div>
-<p>Before we can use most <code>taxald</code> functions, we need to do a one-time installation of the database <code>taxald</code> uses for almost all commands. This can take a while to run, but needs only be done once. The database is installed on your local hard-disk and will persist between R sessions. By default, the database will be installed in your user’s application data directory, as detected by the <code>rappdirs</code> package. (Set a custom location instead using <code>dbdir</code> argument.)</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(taxald)
-<span class="kw"><a href="../reference/td_create.html">td_create</a></span>()</code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1">devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"cboettig/taxadb"</span>)</a></code></pre></div>
+<p>Before we can use most <code>taxadb</code> functions, we need to do a one-time installation of the database <code>taxadb</code> uses for almost all commands. This can take a while to run, but needs only be done once. The database is installed on your local hard-disk and will persist between R sessions. By default, the database will be installed in your user’s application data directory, as detected by the <code>rappdirs</code> package. (Set a custom location instead using <code>dbdir</code> argument.)</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="kw">library</span>(taxadb)</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="kw"><a href="../reference/td_create.html">td_create</a></span>()</a></code></pre></div>
 <p>The default behavior installs only the ITIS database. You can also specify a list of authorities to install, or install every authority using <code><a href="../reference/td_create.html">td_create("all")</a></code>.</p>
 </div>
 <div id="test-drive" class="section level2">
@@ -115,22 +116,22 @@
 <a href="#test-drive" class="anchor"></a>Test drive</h2>
 <p>Once the databases have been set up, we’re ready to explore.<br>
 Here’s a list of all the birds species known to ITIS:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/descendants.html">descendants</a></span>(<span class="dt">name =</span> <span class="st">"Aves"</span>, <span class="dt">rank =</span> <span class="st">"class"</span>)</code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="../reference/descendants.html">descendants</a></span>(<span class="dt">name =</span> <span class="st">"Aves"</span>, <span class="dt">rank =</span> <span class="st">"class"</span>)</a></code></pre></div>
 </div>
 <div id="learn-more" class="section level2">
 <h2 class="hasAnchor">
 <a href="#learn-more" class="anchor"></a>Learn More</h2>
-<div id="an-introduction-to-taxald" class="section level3">
+<div id="an-introduction-to-taxadb" class="section level3">
 <h3 class="hasAnchor">
-<a href="#an-introduction-to-taxald" class="anchor"></a><a href="https://cboettig.github.io/taxald/articles/articles/taxald.html">An introduction to taxald</a>
+<a href="#an-introduction-to-taxadb" class="anchor"></a><a href="https://cboettig.github.io/taxadb/articles/articles/taxadb.html">An introduction to taxadb</a>
 </h3>
-<p>The <a href="https://cboettig.github.io/taxald/articles/articles/taxald.html">taxald introduction</a> provides an overview showing how <code>taxald</code> functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.</p>
+<p>The <a href="https://cboettig.github.io/taxadb/articles/articles/taxadb.html">taxadb introduction</a> provides an overview showing how <code>taxadb</code> functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.</p>
 </div>
-<div id="taxald-schemas" class="section level3">
+<div id="taxadb-schemas" class="section level3">
 <h3 class="hasAnchor">
-<a href="#taxald-schemas" class="anchor"></a><a href="https://cboettig.github.io/taxald/articles/articles/schema.html">taxald schemas</a>
+<a href="#taxadb-schemas" class="anchor"></a><a href="https://cboettig.github.io/taxadb/articles/articles/schema.html">taxadb schemas</a>
 </h3>
-<p>See the <a href="https://cboettig.github.io/taxald/articles/articles/schema.html">schemas</a> vignette for an overview of the underlying tables used by <code>taxald</code> functions, and more about the different authorities accessed by taxald.</p>
+<p>See the <a href="https://cboettig.github.io/taxadb/articles/articles/schema.html">schemas</a> vignette for an overview of the underlying tables used by <code>taxadb</code> functions, and more about the different authorities accessed by taxadb.</p>
 </div>
 </div>
   </div>
@@ -155,8 +156,9 @@ Here’s a list of all the birds species known to ITIS:</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
 </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Authors • taxald</title>
+<title>Authors • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -35,8 +37,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -59,8 +60,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -86,13 +87,13 @@
       <a href="articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="articles/articles/schema.html">Database schema for taxald</a>
+      <a href="articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="articles/articles/taxald.html">taxald overview</a>
+      <a href="articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="articles/intro.html">Quickstart for taxald</a>
+      <a href="articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -100,7 +101,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -150,8 +151,9 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,15 +5,16 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Taxonomic Linked Data  • taxald</title>
-<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
+<title>Taxonomic Linked Data  • taxadb</title>
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
 <script src="pkgdown.js"></script><meta property="og:title" content="Taxonomic Linked Data ">
 <meta property="og:description" content="Creates a local database of many commonly used taxonomic authorities
              and provides functions that can quickly query this data.  ">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -30,8 +31,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -57,20 +58,20 @@
       <a href="articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="articles/articles/schema.html">Database schema for taxald</a>
+      <a href="articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="articles/articles/taxald.html">taxald overview</a>
+      <a href="articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="articles/intro.html">Quickstart for taxald</a>
+      <a href="articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -92,22 +93,26 @@
     
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-<div id="taxald" class="section level1">
+<div id="taxadb" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
-<a href="#taxald" class="anchor"></a>taxald</h1></div>
-<p>The goal of <code>taxald</code> is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records.</p>
-<p>Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines. Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. <code>taxald</code> creates a <em>local</em> database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.</p>
+<a href="#taxadb" class="anchor"></a>taxadb</h1></div>
+<p>The goal of <code>taxadb</code> is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records.</p>
+<p>Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines. Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. <code>taxadb</code> creates a <em>local</em> database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.</p>
 <div id="install-and-initial-setup" class="section level2">
 <h2 class="hasAnchor">
 <a href="#install-and-initial-setup" class="anchor"></a>Install and initial setup</h2>
 <p>To get started, install the development version directly from GitHub:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">devtools<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"cboettig/taxald"</span>)</code></pre></div>
-<p>Before we can use most <code>taxald</code> functions, we need to do a one-time installation of the database <code>taxald</code> uses for almost all commands. This can take a while to run, but needs only be done once. The database is installed on your local hard-disk and will persist between R sessions. By default, the database will be installed in your user’s application data directory, as detected by the <code>rappdirs</code> package. (Set a custom location instead using <code>dbdir</code> argument.)</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(taxald)
-<span class="kw"><a href="reference/td_create.html">td_create</a></span>()
-<span class="co">#&gt; not overwriting itis_hierarchy</span>
-<span class="co">#&gt; not overwriting itis_taxonid</span>
-<span class="co">#&gt; not overwriting itis_synonyms</span></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1">devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"cboettig/taxadb"</span>)</a></code></pre></div>
+<p>Before we can use most <code>taxadb</code> functions, we need to do a one-time installation of the database <code>taxadb</code> uses for almost all commands. This can take a while to run, but needs only be done once. The database is installed on your local hard-disk and will persist between R sessions. By default, the database will be installed in your user’s application data directory, as detected by the <code>rappdirs</code> package. (Set a custom location instead using <code>dbdir</code> argument.)</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="kw">library</span>(taxadb)</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="kw"><a href="reference/td_create.html">td_create</a></span>()</a>
+<a class="sourceLine" id="cb2-3" data-line-number="3"><span class="co">#&gt; Importing itis_hierarchy.tsv.bz2 in 1000000 line chunks:</span></a>
+<a class="sourceLine" id="cb2-4" data-line-number="4"><span class="co">#&gt; Identifier(s) "order", "section" are reserved SQL keywords and need(s) to be quoted in queries.</span></a>
+<a class="sourceLine" id="cb2-5" data-line-number="5"><span class="co">#&gt;  ...Done! (in 22.54365 secs)</span></a>
+<a class="sourceLine" id="cb2-6" data-line-number="6"><span class="co">#&gt; Importing itis_taxonid.tsv.bz2 in 1000000 line chunks:</span></a>
+<a class="sourceLine" id="cb2-7" data-line-number="7"><span class="co">#&gt;  ...Done! (in 17.05039 secs)</span></a>
+<a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co">#&gt; Importing itis_synonyms.tsv.bz2 in 1000000 line chunks:</span></a>
+<a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co">#&gt;  ...Done! (in 3.457511 secs)</span></a></code></pre></div>
 <p>The default behavior installs only the ITIS database. You can also specify a list of authorities to install, or install every authority using <code><a href="reference/td_create.html">td_create("all")</a></code>.</p>
 </div>
 <div id="test-drive" class="section level2">
@@ -115,41 +120,41 @@
 <a href="#test-drive" class="anchor"></a>Test drive</h2>
 <p>Once the databases have been set up, we’re ready to explore.<br>
 Here’s a list of all the birds species known to ITIS:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/descendants.html">descendants</a></span>(<span class="dt">name =</span> <span class="st">"Aves"</span>, <span class="dt">rank =</span> <span class="st">"class"</span>)
-<span class="co">#&gt; # A tibble: 10,401 x 26</span>
-<span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span>
-<span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span>
-<span class="co">#&gt;  1 ITIS… Aves  Strut… Stru… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  2 ITIS… Aves  Rheid… Rhea  &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  3 ITIS… Aves  Droma… Drom… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  4 ITIS… Aves  Casua… Casu… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  5 ITIS… Aves  Casua… Casu… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  6 ITIS… Aves  Apter… Apte… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  7 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  8 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt;  9 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt; 10 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span>
-<span class="co">#&gt; # ... with 10,391 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span>
-<span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span>
-<span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span>
-<span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="reference/descendants.html">descendants</a></span>(<span class="dt">name =</span> <span class="st">"Aves"</span>, <span class="dt">rank =</span> <span class="st">"class"</span>)</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"><span class="co">#&gt; # A tibble: 10,401 x 26</span></a>
+<a class="sourceLine" id="cb3-3" data-line-number="3"><span class="co">#&gt;    id    class family genus infraclass infrakingdom infraorder infraphylum</span></a>
+<a class="sourceLine" id="cb3-4" data-line-number="4"><span class="co">#&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;  &lt;chr&gt; &lt;chr&gt;      &lt;chr&gt;        &lt;chr&gt;      &lt;chr&gt;      </span></a>
+<a class="sourceLine" id="cb3-5" data-line-number="5"><span class="co">#&gt;  1 ITIS… Aves  Strut… Stru… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-6" data-line-number="6"><span class="co">#&gt;  2 ITIS… Aves  Rheid… Rhea  &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-7" data-line-number="7"><span class="co">#&gt;  3 ITIS… Aves  Droma… Drom… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-8" data-line-number="8"><span class="co">#&gt;  4 ITIS… Aves  Casua… Casu… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-9" data-line-number="9"><span class="co">#&gt;  5 ITIS… Aves  Casua… Casu… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-10" data-line-number="10"><span class="co">#&gt;  6 ITIS… Aves  Apter… Apte… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-11" data-line-number="11"><span class="co">#&gt;  7 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-12" data-line-number="12"><span class="co">#&gt;  8 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-13" data-line-number="13"><span class="co">#&gt;  9 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-14" data-line-number="14"><span class="co">#&gt; 10 ITIS… Aves  Tinam… Tina… &lt;NA&gt;       Deuterostom… &lt;NA&gt;       Gnathostom…</span></a>
+<a class="sourceLine" id="cb3-15" data-line-number="15"><span class="co">#&gt; # ... with 10,391 more rows, and 18 more variables: kingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-16" data-line-number="16"><span class="co">#&gt; #   order &lt;chr&gt;, phylum &lt;chr&gt;, section &lt;chr&gt;, species &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-17" data-line-number="17"><span class="co">#&gt; #   subclass &lt;chr&gt;, subfamily &lt;chr&gt;, subgenus &lt;chr&gt;, subkingdom &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-18" data-line-number="18"><span class="co">#&gt; #   suborder &lt;chr&gt;, subphylum &lt;chr&gt;, subsection &lt;chr&gt;, subtribe &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-19" data-line-number="19"><span class="co">#&gt; #   superclass &lt;chr&gt;, superfamily &lt;chr&gt;, superorder &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb3-20" data-line-number="20"><span class="co">#&gt; #   superphylum &lt;chr&gt;, tribe &lt;chr&gt;</span></a></code></pre></div>
 </div>
 <div id="learn-more" class="section level2">
 <h2 class="hasAnchor">
 <a href="#learn-more" class="anchor"></a>Learn More</h2>
-<div id="an-introduction-to-taxald" class="section level3">
+<div id="an-introduction-to-taxadb" class="section level3">
 <h3 class="hasAnchor">
-<a href="#an-introduction-to-taxald" class="anchor"></a><a href="https://cboettig.github.io/taxald/articles/articles/taxald.html">An introduction to taxald</a>
+<a href="#an-introduction-to-taxadb" class="anchor"></a><a href="https://cboettig.github.io/taxadb/articles/articles/taxadb.html">An introduction to taxadb</a>
 </h3>
-<p>The <a href="https://cboettig.github.io/taxald/articles/articles/taxald.html">taxald introduction</a> provides an overview showing how <code>taxald</code> functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.</p>
+<p>The <a href="https://cboettig.github.io/taxadb/articles/articles/taxadb.html">taxadb introduction</a> provides an overview showing how <code>taxadb</code> functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.</p>
 </div>
-<div id="taxald-schemas" class="section level3">
+<div id="taxadb-schemas" class="section level3">
 <h3 class="hasAnchor">
-<a href="#taxald-schemas" class="anchor"></a><a href="https://cboettig.github.io/taxald/articles/articles/schema.html">taxald schemas</a>
+<a href="#taxadb-schemas" class="anchor"></a><a href="https://cboettig.github.io/taxadb/articles/articles/schema.html">taxadb schemas</a>
 </h3>
-<p>See the <a href="https://cboettig.github.io/taxald/articles/articles/schema.html">schemas</a> vignette for an overview of the underlying tables used by <code>taxald</code> functions, and more about the different authorities accessed by taxald.</p>
+<p>See the <a href="https://cboettig.github.io/taxadb/articles/articles/schema.html">schemas</a> vignette for an overview of the underlying tables used by <code>taxadb</code> functions, and more about the different authorities accessed by taxadb.</p>
 </div>
 </div>
 </div>
@@ -159,9 +164,9 @@ Here’s a list of all the birds species known to ITIS:</p>
     <div class="links">
 <h2>Links</h2>
 <ul class="list-unstyled">
-<li>Browse source code at <br><a href="https://github.com/cboettig/taxald">https://​github.com/​cboettig/​taxald</a>
+<li>Browse source code at <br><a href="https://github.com/cboettig/taxadb">https://​github.com/​cboettig/​taxadb</a>
 </li>
-<li>Report a bug at <br><a href="https://github.com/cboettig/taxald/issues">https://​github.com/​cboettig/​taxald/​issues</a>
+<li>Report a bug at <br><a href="https://github.com/cboettig/taxadb/issues">https://​github.com/​cboettig/​taxadb/​issues</a>
 </li>
 </ul>
 </div>
@@ -185,10 +190,10 @@ Here’s a list of all the birds species known to ITIS:</p>
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="https://www.tidyverse.org/lifecycle/#maturing"><img src="https://img.shields.io/badge/lifecycle-maturing-blue.svg" alt="lifecycle"></a></li>
-<li><a href="https://travis-ci.org/cboettig/taxald"><img src="https://travis-ci.org/cboettig/taxald.svg?branch=master" alt="Travis build status"></a></li>
-<li><a href="https://ci.appveyor.com/project/cboettig/taxald"><img src="https://ci.appveyor.com/api/projects/status/github/cboettig/taxald?branch=master&amp;svg=true" alt="AppVeyor build status"></a></li>
-<li><a href="https://codecov.io/github/cboettig/taxald?branch=master"><img src="https://codecov.io/gh/cboettig/taxald/branch/master/graph/badge.svg" alt="Coverage status"></a></li>
-<li><a href="https://cran.r-project.org/package=taxald"><img src="https://www.r-pkg.org/badges/version/taxald" alt="CRAN status"></a></li>
+<li><a href="https://travis-ci.org/cboettig/taxadb"><img src="https://travis-ci.org/cboettig/taxadb.svg?branch=master" alt="Travis build status"></a></li>
+<li><a href="https://ci.appveyor.com/project/cboettig/taxadb"><img src="https://ci.appveyor.com/api/projects/status/github/cboettig/taxadb?branch=master&amp;svg=true" alt="AppVeyor build status"></a></li>
+<li><a href="https://codecov.io/github/cboettig/taxadb?branch=master"><img src="https://codecov.io/gh/cboettig/taxadb/branch/master/graph/badge.svg" alt="Coverage status"></a></li>
+<li><a href="https://cran.r-project.org/package=taxadb"><img src="https://www.r-pkg.org/badges/version/taxadb" alt="CRAN status"></a></li>
 </ul>
 </div>
 </div>
@@ -201,8 +206,9 @@ Here’s a list of all the birds species known to ITIS:</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
 </div>
 

--- a/docs/pkgdown.css
+++ b/docs/pkgdown.css
@@ -58,14 +58,9 @@ img {
   max-width: 100%;
 }
 
-/* Fix bug in bootstrap (only seen in firefox) */
-summary {
-  display: list-item;
-}
-
 /* Typographic tweaking ---------------------------------*/
 
-.contents .page-header {
+.contents h1.page-header {
   margin-top: calc(-60px + 1em);
 }
 
@@ -141,9 +136,10 @@ a.anchor {
 .ref-index th {font-weight: normal;}
 
 .ref-index td {vertical-align: top;}
-.ref-index .icon {width: 40px;}
 .ref-index .alias {width: 40%;}
-.ref-index-icons .alias {width: calc(40% - 40px);}
+.ref-index .title {width: 60%;}
+
+.ref-index .alias {width: 40%;}
 .ref-index .title {width: 60%;}
 
 .ref-arguments th {text-align: right; padding-right: 10px;}

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -25,13 +25,9 @@
     for (var i = 0; i < links.length; i++) {
       if (links[i].getAttribute("href") === "#")
         continue;
-      // Ignore external links
-      if (links[i].host !== location.host)
-        continue;
+      var path = paths(links[i].pathname);
 
-      var nav_path = paths(links[i].pathname);
-
-      var length = prefix_length(nav_path, cur_path);
+      var length = prefix_length(cur_path, path);
       if (length > max_length) {
         max_length = length;
         pos = i;
@@ -56,14 +52,13 @@
     return(pieces);
   }
 
-  // Returns -1 if not found
   function prefix_length(needle, haystack) {
     if (needle.length > haystack.length)
-      return(-1);
+      return(0);
 
     // Special case for length-0 haystack, since for loop won't run
     if (haystack.length === 0) {
-      return(needle.length === 0 ? 0 : -1);
+      return(needle.length === 0 ? 1 : 0);
     }
 
     for (var i = 0; i < haystack.length; i++) {
@@ -83,7 +78,7 @@
     element.setAttribute('data-original-title', tooltipOriginalTitle);
   }
 
-  if(ClipboardJS.isSupported()) {
+  if(Clipboard.isSupported()) {
     $(document).ready(function() {
       var copyButton = "<button type='button' class='btn btn-primary btn-copy-ex' type = 'submit' title='Copy to clipboard' aria-label='Copy to clipboard' data-toggle='tooltip' data-placement='left auto' data-trigger='hover' data-clipboard-copy><i class='fa fa-copy'></i></button>";
 
@@ -96,7 +91,7 @@
       $('.btn-copy-ex').tooltip({container: 'body'});
 
       // Initialize clipboard:
-      var clipboardBtnCopies = new ClipboardJS('[data-clipboard-copy]', {
+      var clipboardBtnCopies = new Clipboard('[data-clipboard-copy]', {
         text: function(trigger) {
           return trigger.parentNode.textContent;
         }

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,6 +1,6 @@
-pandoc: 1.19.2.1
-pkgdown: 1.3.0
-pkgdown_sha: ~
+pandoc: 2.3.1
+pkgdown: 1.1.0.9000
+pkgdown_sha: 16c6506a153dacf99c185f0ef62488458297d301
 articles:
   crosswalk: articles/crosswalk.html
   schema: articles/schema.html

--- a/docs/reference/classification.html
+++ b/docs/reference/classification.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Return the full classification hierarchy for requested species or ids — classification • taxald</title>
+<title>Return the full classification hierarchy for requested species or ids — classification • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Return the full classification hierarchy for requested species or ids</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/classification.R'><code>R/classification.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/classification.R'><code>R/classification.R</code></a></small>
     <div class="hidden name"><code>classification.Rd</code></div>
     </div>
 
@@ -131,7 +132,7 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>classification</span>(<span class='kw'>species</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>,
+    <pre class="usage"><span class='fu'>classification</span>(<span class='kw'>species</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>,
   <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>, <span class='st'>"wd"</span>), <span class='kw'>collect</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>())</pre>
     
@@ -147,7 +148,7 @@ specified as (<code>Genus species</code> or <code>Genus species epithet</code>)<
       <th>id</th>
       <td><p>alternately users can provide a vector of species ids.
 IDs must be prefixed matching the requested authority.  See <code>id</code>
-column returned by most <code>taxald</code> functions for examples.</p></td>
+column returned by most <code>taxadb</code> functions for examples.</p></td>
     </tr>
     <tr>
       <th>authority</th>
@@ -163,7 +164,7 @@ first perform subsequent filtering operations.)</p></td>
     </tr>
     <tr>
       <th>db</th>
-      <td><p>a connection to the taxald database. See details.</p></td>
+      <td><p>a connection to the taxadb database. See details.</p></td>
     </tr>
     </table>
     
@@ -205,8 +206,9 @@ see the "long" schema for more complete classification.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/descendants.html
+++ b/docs/reference/descendants.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get all members (descendants) of a given rank level — descendants • taxald</title>
+<title>Get all members (descendants) of a given rank level — descendants • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Get all members (descendants) of a given rank level</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/descendants.R'><code>R/descendants.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/descendants.R'><code>R/descendants.R</code></a></small>
     <div class="hidden name"><code>descendants.Rd</code></div>
     </div>
 
@@ -132,7 +133,7 @@
     </div>
 
     <pre class="usage"><span class='fu'>descendants</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>rank</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>, <span class='st'>"wd"</span>),
+  <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>, <span class='st'>"wd"</span>),
   <span class='kw'>collect</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>(), <span class='kw'>schema</span> <span class='kw'>=</span> <span class='st'>"hierarchy"</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -150,7 +151,7 @@
       <th>id</th>
       <td><p>alternately users can provide a vector of species ids.
 IDs must be prefixed matching the requested authority.  See <code>id</code>
-column returned by most <code>taxald</code> functions for examples.</p></td>
+column returned by most <code>taxadb</code> functions for examples.</p></td>
     </tr>
     <tr>
       <th>authority</th>
@@ -166,7 +167,7 @@ first perform subsequent filtering operations.)</p></td>
     </tr>
     <tr>
       <th>db</th>
-      <td><p>a connection to the taxald database. See details.</p></td>
+      <td><p>a connection to the taxadb database. See details.</p></td>
     </tr>
     <tr>
       <th>schema</th>
@@ -197,8 +198,9 @@ first perform subsequent filtering operations.)</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/get_ids.html
+++ b/docs/reference/get_ids.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>get_ids — get_ids • taxald</title>
+<title>get_ids — get_ids • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>get_ids</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/taxize.R'><code>R/taxize.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/get_ids.R'><code>R/get_ids.R</code></a></small>
     <div class="hidden name"><code>get_ids.Rd</code></div>
     </div>
 
@@ -131,8 +132,8 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>get_ids</span>(<span class='no'>names</span>, <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>,
-  <span class='st'>"wd"</span>), <span class='kw'>format</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"bare"</span>, <span class='st'>"prefix"</span>, <span class='st'>"uri"</span>), <span class='kw'>taxald_db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>(),
+    <pre class="usage"><span class='fu'>get_ids</span>(<span class='no'>names</span>, <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>,
+  <span class='st'>"wd"</span>), <span class='kw'>format</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"bare"</span>, <span class='st'>"prefix"</span>, <span class='st'>"uri"</span>), <span class='kw'>taxadb_db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>(),
   <span class='no'>...</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -150,14 +151,14 @@ include higher-order ranks in most authorities).</p></td>
     <tr>
       <th>format</th>
       <td><p>Format for the returned: bare identifier, one of</p><ul>
-<li><p><code>bare</code> (e.g. <code>9606</code>, default, matching <code>taxize::get_ids()</code>),</p></li>
+<li><p><code>bare</code> (e.g. <code>9606</code>, default, matching <code><a href='http://www.rdocumentation.org/packages/taxize/topics/get_ids'>taxize::get_ids()</a></code>),</p></li>
 <li><p><code>prefix</code> (e.g. <code>NCBI:9606</code>), or</p></li>
 <li><p><code>uri</code> (e.g.
 <code>http://ncbi.nlm.nih.gov/taxonomy/9606</code>).</p></li>
 </ul></td>
     </tr>
     <tr>
-      <th>taxald_db</th>
+      <th>taxadb_db</th>
       <td><p>Connection to from <code>[td_connect]()</code>.</p></td>
     </tr>
     <tr>
@@ -169,16 +170,16 @@ include higher-order ranks in most authorities).</p></td>
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
     <p>Note that some taxize authorities: <code>nbn</code>, <code>tropicos</code>, and <code>eol</code>,
-are not recognized by taxald and will throw an error here. Meanwhile,
-taxald recognizes several authorities not known to <code>[taxize::get_ids()]</code>.
+are not recognized by taxadb and will throw an error here. Meanwhile,
+taxadb recognizes several authorities not known to <code>[taxize::get_ids()]</code>.
 Both include <code>itis</code>, <code>ncbi</code>, <code>col</code>, and <code>gbif</code>.</p>
-<p>Like all taxald functions, this function will run
+<p>Like all taxadb functions, this function will run
 fastest if a local copy of the authority is installed in advance
 using <code>[td_create()]</code>.</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='fu'>get_ids</span>(<span class='st'>"Homo sapiens"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div><div class='input'><span class='fu'>get_ids</span>(<span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"Homo sapiens"</span>, <span class='st'>"Mammalia"</span>), <span class='kw'>format</span> <span class='kw'>=</span> <span class='st'>"prefix"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div><div class='input'><span class='fu'>get_ids</span>(<span class='st'>"Homo sapiens"</span>, <span class='kw'>db</span><span class='kw'>=</span> <span class='st'>"ncbi"</span>, <span class='kw'>format</span> <span class='kw'>=</span> <span class='st'>"uri"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div></pre>
+    <pre class="examples"><div class='input'><span class='fu'>get_ids</span>(<span class='st'>"Homo sapiens"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div><div class='input'><span class='fu'>get_ids</span>(<span class='fu'>c</span>(<span class='st'>"Homo sapiens"</span>, <span class='st'>"Mammalia"</span>), <span class='kw'>format</span> <span class='kw'>=</span> <span class='st'>"prefix"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div><div class='input'><span class='fu'>get_ids</span>(<span class='st'>"Homo sapiens"</span>, <span class='kw'>db</span><span class='kw'>=</span> <span class='st'>"ncbi"</span>, <span class='kw'>format</span> <span class='kw'>=</span> <span class='st'>"uri"</span>)</div><div class='output co'>#&gt; <span class='error'>Error in pull(., "accepted_id"): could not find function "pull"</span></div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
@@ -199,8 +200,9 @@ using <code>[td_create()]</code>.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/ids.html
+++ b/docs/reference/ids.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Return taxonomic identifiers from a given namespace — ids • taxald</title>
+<title>Return taxonomic identifiers from a given namespace — ids • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Return taxonomic identifiers from a given namespace</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/ids.R'><code>R/ids.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/ids.R'><code>R/ids.R</code></a></small>
     <div class="hidden name"><code>ids.Rd</code></div>
     </div>
 
@@ -131,7 +132,7 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>ids</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>,
+    <pre class="usage"><span class='fu'>ids</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>,
   <span class='st'>"fb"</span>, <span class='st'>"slb"</span>, <span class='st'>"wd"</span>), <span class='kw'>collect</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>())</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -157,25 +158,25 @@ first perform subsequent filtering operations.)</p></td>
     </tr>
     <tr>
       <th>db</th>
-      <td><p>a connection to the taxald database. See details.</p></td>
-    </tr>
-    <tr>
-      <th>pull</th>
-      <td><p>logical, should we pull out the id column or return the full table?</p></td>
+      <td><p>a connection to the taxadb database. See details.</p></td>
     </tr>
     </table>
     
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
     <p>a data.frame with columns of <code>id</code>, scientific
-<code>name</code>, and <code>rank</code> and a row for each species name queried.</p>
+<code>name</code>, and <code>rank</code>, and <code>accepted_id</code> (if data includes synonyms)
+and a row for each species name queried.</p>
     
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>NOTE on matching synonyms: Some authorities (like ITIS) issue separate synonym_ids
-corresponding to synonym names. The <code>ids()</code> function <em>does not</em> return synonym ids.
-Rather, if a name is recognized as a synonym, we will look up the appropriate
-accepted name and the ID associated with the accepted name and return that.</p>
+    <p>Some authorities (ITIS, COL, FB/SLB, NCBI) provide synonyms as well.  These
+are included in the name list search.  The data.frame returned will then
+include an <code>accepted_id</code> column, providing the synonym for the requested table.
+In this case, the <code>id</code> column corresponds to the id for either the name column --
+that is, if the name is a synonym, this is the id for the synonym; if the name
+is accepted, this id is the same as the accepted id.  NCBI does not issue ids
+for known synonyms, so the id is missing for synonym names in this case.</p>
     
 
   </div>
@@ -198,8 +199,9 @@ accepted name and the ID associated with the accepted name and return that.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Function reference • taxald</title>
+<title>Function reference • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -35,8 +37,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -59,8 +60,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -86,13 +87,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -100,7 +101,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -170,13 +171,13 @@
         <td>
           <p><code><a href="taxa_tbl.html">taxa_tbl()</a></code> </p>
         </td>
-        <td><p>Return a reference to a given table in the taxald database</p></td>
+        <td><p>Return a reference to a given table in the taxadb database</p></td>
       </tr><tr>
         
         <td>
           <p><code><a href="td_connect.html">td_connect()</a></code> </p>
         </td>
-        <td><p>Connect to the taxald database</p></td>
+        <td><p>Connect to the taxadb database</p></td>
       </tr><tr>
         
         <td>
@@ -202,8 +203,9 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/synonyms.html
+++ b/docs/reference/synonyms.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>synonyms — synonyms • taxald</title>
+<title>synonyms — synonyms • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>synonyms</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/synonyms.R'><code>R/synonyms.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/synonyms.R'><code>R/synonyms.R</code></a></small>
     <div class="hidden name"><code>synonyms.Rd</code></div>
     </div>
 
@@ -131,7 +132,7 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>synonyms</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>,
+    <pre class="usage"><span class='fu'>synonyms</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>,
   <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>, <span class='st'>"wd"</span>), <span class='kw'>collect</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>())</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -157,7 +158,7 @@ first perform subsequent filtering operations.)</p></td>
     </tr>
     <tr>
       <th>db</th>
-      <td><p>a connection to the taxald database. See details.</p></td>
+      <td><p>a connection to the taxadb database. See details.</p></td>
     </tr>
     </table>
     
@@ -178,8 +179,9 @@ first perform subsequent filtering operations.)</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/taxa_tbl.html
+++ b/docs/reference/taxa_tbl.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Return a reference to a given table in the taxald database — taxa_tbl • taxald</title>
+<title>Return a reference to a given table in the taxadb database — taxa_tbl • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -30,16 +32,15 @@
 
 
 
-<meta property="og:title" content="Return a reference to a given table in the taxald database — taxa_tbl" />
+<meta property="og:title" content="Return a reference to a given table in the taxadb database — taxa_tbl" />
 
-<meta property="og:description" content="Return a reference to a given table in the taxald database" />
+<meta property="og:description" content="Return a reference to a given table in the taxadb database" />
 <meta name="twitter:card" content="summary" />
 
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -120,19 +121,19 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Return a reference to a given table in the taxald database</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/taxa_tbl.R'><code>R/taxa_tbl.R</code></a></small>
+    <h1>Return a reference to a given table in the taxadb database</h1>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/taxa_tbl.R'><code>R/taxa_tbl.R</code></a></small>
     <div class="hidden name"><code>taxa_tbl.Rd</code></div>
     </div>
 
     <div class="ref-description">
     
-    <p>Return a reference to a given table in the taxald database</p>
+    <p>Return a reference to a given table in the taxadb database</p>
     
     </div>
 
-    <pre class="usage"><span class='fu'>taxa_tbl</span>(<span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>,
-  <span class='st'>"wd"</span>), <span class='kw'>schema</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"hierarchy"</span>, <span class='st'>"taxonid"</span>, <span class='st'>"synonyms"</span>, <span class='st'>"common"</span>,
+    <pre class="usage"><span class='fu'>taxa_tbl</span>(<span class='kw'>authority</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"itis"</span>, <span class='st'>"ncbi"</span>, <span class='st'>"col"</span>, <span class='st'>"tpl"</span>, <span class='st'>"gbif"</span>, <span class='st'>"fb"</span>, <span class='st'>"slb"</span>,
+  <span class='st'>"wd"</span>), <span class='kw'>schema</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"hierarchy"</span>, <span class='st'>"taxonid"</span>, <span class='st'>"synonyms"</span>, <span class='st'>"common"</span>,
   <span class='st'>"long"</span>), <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>())</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -149,7 +150,7 @@ Default is 'itis'.</p></td>
     </tr>
     <tr>
       <th>db</th>
-      <td><p>a connection to the taxald database. Default will
+      <td><p>a connection to the taxadb database. Default will
 attempt to connect automatically.</p></td>
     </tr>
     </table>
@@ -171,8 +172,9 @@ attempt to connect automatically.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/td_connect.html
+++ b/docs/reference/td_connect.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Connect to the taxald database — td_connect • taxald</title>
+<title>Connect to the taxadb database — td_connect • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -30,16 +32,15 @@
 
 
 
-<meta property="og:title" content="Connect to the taxald database — td_connect" />
+<meta property="og:title" content="Connect to the taxadb database — td_connect" />
 
-<meta property="og:description" content="Connect to the taxald database" />
+<meta property="og:description" content="Connect to the taxadb database" />
 <meta name="twitter:card" content="summary" />
 
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -120,18 +121,18 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Connect to the taxald database</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/td_connect.R'><code>R/td_connect.R</code></a></small>
+    <h1>Connect to the taxadb database</h1>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/td_connect.R'><code>R/td_connect.R</code></a></small>
     <div class="hidden name"><code>td_connect.Rd</code></div>
     </div>
 
     <div class="ref-description">
     
-    <p>Connect to the taxald database</p>
+    <p>Connect to the taxadb database</p>
     
     </div>
 
-    <pre class="usage"><span class='fu'>td_connect</span>(<span class='kw'>dbdir</span> <span class='kw'>=</span> <span class='kw pkg'>rappdirs</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/rappdirs/topics/user_data_dir'>user_data_dir</a></span>(<span class='st'>"taxald"</span>))</pre>
+    <pre class="usage"><span class='fu'>td_connect</span>(<span class='kw'>dbdir</span> <span class='kw'>=</span> <span class='kw pkg'>rappdirs</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/rappdirs/topics/user_data_dir'>user_data_dir</a></span>(<span class='st'>"taxadb"</span>))</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -149,7 +150,7 @@
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
     <p>Primarily useful when a lower-level interface to the
-database is required.  Most <code>taxald</code> functions will connect
+database is required.  Most <code>taxadb</code> functions will connect
 automatically without the user needing to call this function.</p>
     
 
@@ -180,8 +181,9 @@ automatically without the user needing to call this function.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/docs/reference/td_create.html
+++ b/docs/reference/td_create.html
@@ -6,20 +6,22 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>create a local taxonomic database — td_create • taxald</title>
+<title>create a local taxonomic database — td_create • taxadb</title>
+
+<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -38,8 +40,7 @@
 
 
 <!-- mathjax -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -62,8 +63,8 @@
         <span class="icon-bar"></span>
       </button>
       <span class="navbar-brand">
-        <a class="navbar-link" href="../index.html">taxald</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
+        <a class="navbar-link" href="../index.html">taxadb</a>
+        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9000</span>
       </span>
     </div>
 
@@ -89,13 +90,13 @@
       <a href="../articles/articles/crosswalk.html">Crosswalking The Authorities</a>
     </li>
     <li>
-      <a href="../articles/articles/schema.html">Database schema for taxald</a>
+      <a href="../articles/articles/schema.html">Database schema for taxadb</a>
     </li>
     <li>
-      <a href="../articles/articles/taxald.html">taxald overview</a>
+      <a href="../articles/articles/taxald.html">taxadb overview</a>
     </li>
     <li>
-      <a href="../articles/intro.html">Quickstart for taxald</a>
+      <a href="../articles/intro.html">Quickstart for taxadb</a>
     </li>
   </ul>
 </li>
@@ -103,7 +104,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/cboettig/taxald">
+  <a href="https://github.com/cboettig/taxadb">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -121,7 +122,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>create a local taxonomic database</h1>
-    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxald/blob/master/R/td_create.R'><code>R/td_create.R</code></a></small>
+    <small class="dont-index">Source: <a href='https://github.com/cboettig/taxadb/blob/master/R/td_create.R'><code>R/td_create.R</code></a></small>
     <div class="hidden name"><code>td_create.Rd</code></div>
     </div>
 
@@ -131,9 +132,9 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>td_create</span>(<span class='kw'>authorities</span> <span class='kw'>=</span> <span class='st'>"itis"</span>, <span class='kw'>schema</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"hierarchy"</span>, <span class='st'>"taxonid"</span>,
+    <pre class="usage"><span class='fu'>td_create</span>(<span class='kw'>authorities</span> <span class='kw'>=</span> <span class='st'>"itis"</span>, <span class='kw'>schema</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"hierarchy"</span>, <span class='st'>"taxonid"</span>,
   <span class='st'>"synonyms"</span>), <span class='kw'>overwrite</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>lines</span> <span class='kw'>=</span> <span class='fl'>1e+06</span>,
-  <span class='kw'>dbdir</span> <span class='kw'>=</span> <span class='kw pkg'>rappdirs</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/rappdirs/topics/user_data_dir'>user_data_dir</a></span>(<span class='st'>"taxald"</span>), <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>(<span class='no'>dbdir</span>))</pre>
+  <span class='kw'>dbdir</span> <span class='kw'>=</span> <span class='kw pkg'>rappdirs</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/rappdirs/topics/user_data_dir'>user_data_dir</a></span>(<span class='st'>"taxadb"</span>), <span class='kw'>db</span> <span class='kw'>=</span> <span class='fu'><a href='td_connect.html'>td_connect</a></span>(<span class='no'>dbdir</span>))</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -166,7 +167,7 @@ Defaults to user data directory given by <a href='rappdirs::user_data_dir'>rappd
     </tr>
     <tr>
       <th>db</th>
-      <td><p>connection to a database.  By default, taxald will set up its own
+      <td><p>connection to a database.  By default, taxadb will set up its own
 fast <a href='MonetDBLite::MonetDBLite'>MonetDBLite::MonetDBLite</a> connection.</p></td>
     </tr>
     </table>
@@ -177,7 +178,7 @@ fast <a href='MonetDBLite::MonetDBLite'>MonetDBLite::MonetDBLite</a> connection.
     
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>Authorities recognized by taxald are:</p><ul>
+    <p>Authorities recognized by taxadb are:</p><ul>
 <li><p><code>itis</code></p></li>
 <li><p><code>ncbi</code></p></li>
 <li><p><code>col</code></p></li>
@@ -218,8 +219,9 @@ fast <a href='MonetDBLite::MonetDBLite'>MonetDBLite::MonetDBLite</a> connection.
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
+
       </footer>
    </div>
 

--- a/man/classification.Rd
+++ b/man/classification.Rd
@@ -14,7 +14,7 @@ specified as (\code{Genus species} or \code{Genus species epithet})}
 
 \item{id}{alternately users can provide a vector of species ids.
 IDs must be prefixed matching the requested authority.  See \code{id}
-column returned by most \code{taxald} functions for examples.}
+column returned by most \code{taxadb} functions for examples.}
 
 \item{authority}{from which authority should the hierachy be returned?
 Default is 'itis'.}
@@ -24,7 +24,7 @@ data.frame (default, usually the most convenient), or a reference to
 lazy-eval table on disk (useful for very large tables on which we may
 first perform subsequent filtering operations.)}
 
-\item{db}{a connection to the taxald database. See details.}
+\item{db}{a connection to the taxadb database. See details.}
 }
 \value{
 a data.frame with one row for each requested species,

--- a/man/descendants.Rd
+++ b/man/descendants.Rd
@@ -15,7 +15,7 @@ descendants(name = NULL, rank = NULL, id = NULL,
 
 \item{id}{alternately users can provide a vector of species ids.
 IDs must be prefixed matching the requested authority.  See \code{id}
-column returned by most \code{taxald} functions for examples.}
+column returned by most \code{taxadb} functions for examples.}
 
 \item{authority}{from which authority should the hierachy be returned?
 Default is 'itis'.}
@@ -25,7 +25,7 @@ data.frame (default, usually the most convenient), or a reference to
 lazy-eval table on disk (useful for very large tables on which we may
 first perform subsequent filtering operations.)}
 
-\item{db}{a connection to the taxald database. See details.}
+\item{db}{a connection to the taxadb database. See details.}
 
 \item{schema}{table schema to use (WIP)}
 }

--- a/man/get_ids.Rd
+++ b/man/get_ids.Rd
@@ -5,7 +5,7 @@
 \title{get_ids}
 \usage{
 get_ids(names, db = c("itis", "ncbi", "col", "tpl", "gbif", "fb", "slb",
-  "wd"), format = c("bare", "prefix", "uri"), taxald_db = td_connect(),
+  "wd"), format = c("bare", "prefix", "uri"), taxadb_db = td_connect(),
   ...)
 }
 \arguments{
@@ -22,7 +22,7 @@ include higher-order ranks in most authorities).}
 \code{http://ncbi.nlm.nih.gov/taxonomy/9606}).
 }}
 
-\item{taxald_db}{Connection to from \code{[td_connect]()}.}
+\item{taxadb_db}{Connection to from \code{[td_connect]()}.}
 
 \item{...}{additional arguments passed to \code{ids()}}
 }
@@ -31,11 +31,11 @@ A drop-in replacement for \code{[taxize::get_ids()]}
 }
 \details{
 Note that some taxize authorities: \code{nbn}, \code{tropicos}, and \code{eol},
-are not recognized by taxald and will throw an error here. Meanwhile,
-taxald recognizes several authorities not known to \code{[taxize::get_ids()]}.
+are not recognized by taxadb and will throw an error here. Meanwhile,
+taxadb recognizes several authorities not known to \code{[taxize::get_ids()]}.
 Both include \code{itis}, \code{ncbi}, \code{col}, and \code{gbif}.
 
-Like all taxald functions, this function will run
+Like all taxadb functions, this function will run
 fastest if a local copy of the authority is installed in advance
 using \code{[td_create()]}.
 }

--- a/man/ids.Rd
+++ b/man/ids.Rd
@@ -20,7 +20,7 @@ data.frame (default, usually the most convenient), or a reference to
 lazy-eval table on disk (useful for very large tables on which we may
 first perform subsequent filtering operations.)}
 
-\item{db}{a connection to the taxald database. See details.}
+\item{db}{a connection to the taxadb database. See details.}
 }
 \value{
 a data.frame with columns of \code{id}, scientific

--- a/man/synonyms.Rd
+++ b/man/synonyms.Rd
@@ -20,7 +20,7 @@ data.frame (default, usually the most convenient), or a reference to
 lazy-eval table on disk (useful for very large tables on which we may
 first perform subsequent filtering operations.)}
 
-\item{db}{a connection to the taxald database. See details.}
+\item{db}{a connection to the taxadb database. See details.}
 }
 \description{
 Resolve provided list of names against all known synonyms

--- a/man/taxa_tbl.Rd
+++ b/man/taxa_tbl.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/taxa_tbl.R
 \name{taxa_tbl}
 \alias{taxa_tbl}
-\title{Return a reference to a given table in the taxald database}
+\title{Return a reference to a given table in the taxadb database}
 \usage{
 taxa_tbl(authority = c("itis", "ncbi", "col", "tpl", "gbif", "fb", "slb",
   "wd"), schema = c("hierarchy", "taxonid", "synonyms", "common",
@@ -14,9 +14,9 @@ Default is 'itis'.}
 
 \item{schema}{the table schema on which we want to run the query}
 
-\item{db}{a connection to the taxald database. Default will
+\item{db}{a connection to the taxadb database. Default will
 attempt to connect automatically.}
 }
 \description{
-Return a reference to a given table in the taxald database
+Return a reference to a given table in the taxadb database
 }

--- a/man/td_connect.Rd
+++ b/man/td_connect.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/td_connect.R
 \name{td_connect}
 \alias{td_connect}
-\title{Connect to the taxald database}
+\title{Connect to the taxadb database}
 \usage{
-td_connect(dbdir = rappdirs::user_data_dir("taxald"))
+td_connect(dbdir = rappdirs::user_data_dir("taxadb"))
 }
 \arguments{
 \item{dbdir}{Path to the database.}
@@ -13,11 +13,11 @@ td_connect(dbdir = rappdirs::user_data_dir("taxald"))
 Returns a \code{src_dbi} connection to the database
 }
 \description{
-Connect to the taxald database
+Connect to the taxadb database
 }
 \details{
 Primarily useful when a lower-level interface to the
-database is required.  Most \code{taxald} functions will connect
+database is required.  Most \code{taxadb} functions will connect
 automatically without the user needing to call this function.
 }
 \examples{

--- a/man/td_create.Rd
+++ b/man/td_create.Rd
@@ -6,7 +6,7 @@
 \usage{
 td_create(authorities = "itis", schema = c("hierarchy", "taxonid",
   "synonyms"), overwrite = FALSE, lines = 1e+06,
-  dbdir = rappdirs::user_data_dir("taxald"), db = td_connect(dbdir))
+  dbdir = rappdirs::user_data_dir("taxadb"), db = td_connect(dbdir))
 }
 \arguments{
 \item{authorities}{a list (character vector) of authorities to be included in the
@@ -25,7 +25,7 @@ at default or increase for faster importing if you have plenty of spare RAM.}
 \item{dbdir}{a location on your computer where the database should be installed.
 Defaults to user data directory given by \url{rappdirs::user_data_dir}.}
 
-\item{db}{connection to a database.  By default, taxald will set up its own
+\item{db}{connection to a database.  By default, taxadb will set up its own
 fast \url{MonetDBLite::MonetDBLite} connection.}
 }
 \value{
@@ -35,7 +35,7 @@ path where database has been installed (invisibly)
 create a local taxonomic database
 }
 \details{
-Authorities recognized by taxald are:
+Authorities recognized by taxadb are:
 \itemize{
 \item \code{itis}
 \item \code{ncbi}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
-library(taxald)
+library(taxadb)
 
-test_check("taxald")
+test_check("taxadb")

--- a/tests/testthat/setup-test_db.R
+++ b/tests/testthat/setup-test_db.R
@@ -1,5 +1,5 @@
 
 
-taxald:::td_disconnect()
-test_db <- file.path(tempdir(), "taxald")
+taxadb:::td_disconnect()
+test_db <- file.path(tempdir(), "taxadb")
 dir.create(test_db, showWarnings = FALSE)

--- a/tests/testthat/teardown-tests.R
+++ b/tests/testthat/teardown-tests.R
@@ -1,0 +1,1 @@
+taxadb:::td_disconnect()

--- a/tests/testthat/test-all-dbs.R
+++ b/tests/testthat/test-all-dbs.R
@@ -1,7 +1,7 @@
-context("taxald")
+context("taxadb")
 
 library(testthat)
-library(taxald)
+library(taxadb)
 library(dplyr)
 
 

--- a/tests/testthat/test-connections.R
+++ b/tests/testthat/test-connections.R
@@ -19,7 +19,7 @@ test_that("we can use alternative DBs, such as SQLite", {
 
   ## NOTE: SQLite joins are waaaay slower than MonetDBLite
   dbdir <- tempdir()
-  dbname <- file.path(dbdir, "taxald.sqlite")
+  dbname <- file.path(dbdir, "taxadb.sqlite")
 
   db <- DBI::dbConnect(RSQLite::SQLite(), dbname = dbname)
 

--- a/tests/testthat/test-fast.R
+++ b/tests/testthat/test-fast.R
@@ -1,7 +1,7 @@
 context("fast")
 
 library(testthat)
-library(taxald)
+library(taxadb)
 library(dplyr)
 
 

--- a/tests/testthat/test-get_ids.R
+++ b/tests/testthat/test-get_ids.R
@@ -4,14 +4,14 @@ test_that("we can use get_ids options", {
 
   db <- td_connect(test_db)
 
-  bare <- get_ids("Homo sapiens", taxald_db = db)
+  bare <- get_ids("Homo sapiens", taxadb_db = db)
   expect_identical(bare, "180092")
 
   some_ids <- get_ids(c("Homo sapiens", "Mammalia"),
-                      format = "prefix", taxald_db = db)
+                      format = "prefix", taxadb_db = db)
 
   expect_identical(some_ids,  c("ITIS:180092", "ITIS:179913"))
-  uri <- get_ids("Homo sapiens", db= "ncbi", format = "uri", taxald_db = db)
+  uri <- get_ids("Homo sapiens", db= "ncbi", format = "uri", taxadb_db = db)
   expect_identical("http://ncbi.nlm.nih.gov/taxonomy/9606",
                    uri)
 })
@@ -21,7 +21,7 @@ test_that("we can get ids without a DB", {
 
   db <- td_connect(test_db)
 
-  bare <- get_ids("Homo sapiens", taxald_db = NULL)
+  bare <- get_ids("Homo sapiens", taxadb_db = NULL)
   expect_identical(bare, "180092")
 
 })

--- a/tests/testthat/test-taxald.R
+++ b/tests/testthat/test-taxald.R
@@ -1,7 +1,7 @@
-context("taxald")
+context("taxadb")
 
 library(testthat)
-library(taxald)
+library(taxadb)
 library(dplyr)
 
 

--- a/vignettes/articles/crosswalk.Rmd
+++ b/vignettes/articles/crosswalk.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 
 ```{r message = FALSE}
-library(taxald)
+library(taxadb)
 library(dplyr)
 library(tidyr)
 ```
@@ -103,3 +103,10 @@ has_match <- my_taxa %>%
 
 my_taxa %>% filter(!has_match)
 ```
+
+
+
+```{r include=FALSE}
+taxadb:::td_disconnect()
+```
+

--- a/vignettes/articles/schema.Rmd
+++ b/vignettes/articles/schema.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Database schema for taxald"
+title: "Database schema for taxadb"
 author: "Carl Boettiger"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 
 
-`taxald` relies on a set of pre-assembled tables following a set of standardized schema layouts outlined below.  The database dumps provided by authorities supported in `taxald` at this time are:
+`taxadb` relies on a set of pre-assembled tables following a set of standardized schema layouts outlined below.  The database dumps provided by authorities supported in `taxadb` at this time are:
 
 - `itis`: [The Integrated Taxonomic Information System](https://www.itis.gov/)
 - `col`: [The Catalogue of Life](http://www.catalogueoflife.org/)
@@ -30,15 +30,15 @@ knitr::opts_chunk$set(
 - `wd`: [WikiData](https://wikidata.org)
 
 
-These authorities provide taxonomic data in a wide range of database formats using a wide range of data layouts (schemas), not all of which are particularly easy to use or interpret (e.g. hierarchies are often but not always specified in `taxon_id,parent_id` pairs.)  To make it faster and easier to work across these authorities, `taxald` defines a common set of table schemas outlined below that are particularly suited for efficient computation of common tasks.  `taxald` pre-processes and publicly archives compressed, flat tables corresponding to each of these schema for each of these authorities.
+These authorities provide taxonomic data in a wide range of database formats using a wide range of data layouts (schemas), not all of which are particularly easy to use or interpret (e.g. hierarchies are often but not always specified in `taxon_id,parent_id` pairs.)  To make it faster and easier to work across these authorities, `taxadb` defines a common set of table schemas outlined below that are particularly suited for efficient computation of common tasks.  `taxadb` pre-processes and publicly archives compressed, flat tables corresponding to each of these schema for each of these authorities.
 
-Using the schema defined below, most common operations can be expressed in terms of very standard operations, such as simple filtering joins in SQL.  to implement these, `taxald` imports the compressed flat files into a local, column-oriented database, [`MonetDBLite`](), which can be installed entirely as an R package with no additional server setup required.  This provides a persistant store, and ensures that operations can be performed on disk since the taxonomic tables considered here are frequently too large to store in active memory.  The columnar structure enables blazingly fast joins.  Once the database is created, `taxald` simply wraps a set of user-friendly R functions around common `SQL` queries, implemented in the popular `dplyr` syntax.  By default, `taxald` will always collect the results of these queries to return familiar, in-memory objects to the R user.  Optional arguments allow more direct access the database queries.  
+Using the schema defined below, most common operations can be expressed in terms of very standard operations, such as simple filtering joins in SQL.  to implement these, `taxadb` imports the compressed flat files into a local, column-oriented database, [`MonetDBLite`](), which can be installed entirely as an R package with no additional server setup required.  This provides a persistant store, and ensures that operations can be performed on disk since the taxonomic tables considered here are frequently too large to store in active memory.  The columnar structure enables blazingly fast joins.  Once the database is created, `taxadb` simply wraps a set of user-friendly R functions around common `SQL` queries, implemented in the popular `dplyr` syntax.  By default, `taxadb` will always collect the results of these queries to return familiar, in-memory objects to the R user.  Optional arguments allow more direct access the database queries.  
 
-This vignette summarizes the table schema defined by `taxald`.  Pre-processing of the original database dumps from each authority into the format described here can be found in the corresponding scripts in `data-raw` directory of the R package source code. 
+This vignette summarizes the table schema defined by `taxadb`.  Pre-processing of the original database dumps from each authority into the format described here can be found in the corresponding scripts in `data-raw` directory of the R package source code. 
 
 
 ```{r message = FALSE}
-library(taxald)
+library(taxadb)
 td_create("all")
 ```
 
@@ -57,7 +57,7 @@ Some authorities may report additional optional columns, such as the `update_dat
 taxa_tbl("itis", "taxonid")
 ```
 
-Note that `taxald` tables report all identifiers using authority prefixes.  Certain authorities only provide taxanomic identifiers to species names (rank is always species).  Currently this includes `gbif`, `fb`, `slb`.  `ncbi`, `col` and `itis` provide taxonomic identifers to scientific names at any rank.   
+Note that `taxadb` tables report all identifiers using authority prefixes.  Certain authorities only provide taxanomic identifiers to species names (rank is always species).  Currently this includes `gbif`, `fb`, `slb`.  `ncbi`, `col` and `itis` provide taxonomic identifers to scientific names at any rank.   
 
 
 ## Hierarchy table
@@ -96,7 +96,7 @@ taxa_tbl("gbif", "synonyms")
 
 ## Common names
 
-Common names are avialable from several authorities, but tidy tables for `taxald` have not yet been implemented.  Common names tables are expected to follow the following schema:
+Common names are avialable from several authorities, but tidy tables for `taxadb` have not yet been implemented.  Common names tables are expected to follow the following schema:
 
 - `id` The taxonomic identifier for the species (or possibly other rank)
 - `name` The common name / vernacular name
@@ -117,7 +117,7 @@ And the following optional columns:
 
 (Most databases do not define `rank_id`, e.g. ids corresponding to the ranks themselves)
 
-These tables are considerably larger and longer than other formats, which can make them slow to query.  Note that for each taxonomic name, `id` and the corresponding `name`, and `rank` of the `id` are repeated across the full path hierarchy.  This format is not installed and not used by functions of `taxald` at this time. 
+These tables are considerably larger and longer than other formats, which can make them slow to query.  Note that for each taxonomic name, `id` and the corresponding `name`, and `rank` of the `id` are repeated across the full path hierarchy.  This format is not installed and not used by functions of `taxadb` at this time. 
 
 A fundamental advantage of this format is that it can be defined identically for every table, meaning that all authorities could be combined into a single table using the long format. both the `taxonid` and `hierarchy` formats can be derived directly from this format, and this format can represent information such as unnamed or duplicate ranks that cannot be represented in the `hierarchy` format.  
 
@@ -136,3 +136,9 @@ taxa_tbl("itis", "long", NULL)
   to a table of standard accepted rank names (i.e. those recognized by ITIS, NCBI, Wikidata),
   and rank names should have 
 - Encoding is UTF-8
+
+
+
+```{r include=FALSE}
+taxadb:::td_disconnect()
+```

--- a/vignettes/articles/taxald.Rmd
+++ b/vignettes/articles/taxald.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "taxald overview"
+title: "taxadb overview"
 author: "Carl Boettiger"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{taxald}
+  %\VignetteIndexEntry{taxadb}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 
 ```{r message = FALSE}
-library(taxald)
+library(taxadb)
 library(dplyr)
 library(tidyr)
 ```
@@ -35,10 +35,10 @@ Unfortunately, as anyone who has attempted this kind of exercise over more than 
 **Synonyms**.  One of the most common problems is the existence of synonyms: different names or different spellings of a given scientific name.  While this could include definite miss-spellings, for there are many species for which authorities can differ in the preferred name -- essentially, two or more different names correspond to the same species, and should be treated as such in our species join.  
 
 
-For instance, we consider the 233 primate species names used in the `geiger` package `primates` data.  To avoid installing that dependency-heavy package, a copy of these names has been cached in `taxald` and can be loaded as follows: 
+For instance, we consider the 233 primate species names used in the `geiger` package `primates` data.  To avoid installing that dependency-heavy package, a copy of these names has been cached in `taxadb` and can be loaded as follows: 
 
 ```{r}
-ex <- system.file("extdata", "primates.tsv.bz2", package = "taxald", mustWork = TRUE)
+ex <- system.file("extdata", "primates.tsv.bz2", package = "taxadb", mustWork = TRUE)
 primates <- readr::read_tsv(ex)
 primates
 ```
@@ -48,7 +48,7 @@ Our goal will be to associate each name with a definitive taxonomic ID of an exi
 
 ## Setup
 
-To get started, we'll install all the data sources available to `taxald` into a local database. This may take a while, particularly over a slow internet connection, but it needs to be done only once.  The downloaded size of all data is around 3 GB.  Once this task completes, our subsequent operations should all be quite fast.  
+To get started, we'll install all the data sources available to `taxadb` into a local database. This may take a while, particularly over a slow internet connection, but it needs to be done only once.  The downloaded size of all data is around 3 GB.  Once this task completes, our subsequent operations should all be quite fast.  
 
 ```{r message=FALSE}
 td_create(authorities = "all")
@@ -141,5 +141,11 @@ the `classification` function can work on species names directly, but this will 
 
 ```{r}
 classification(species = primates$species)
+```
+
+
+
+```{r include=FALSE}
+taxadb:::td_disconnect()
 ```
 

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart for taxald"
+title: "Quickstart for taxadb"
 author: "Carl Boettiger"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
@@ -19,9 +19,9 @@ knitr::opts_chunk$set(
 ```
 
 
-The goal of `taxald` is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records. 
+The goal of `taxadb` is to provide fast access to taxonomic data and manipulations, such as resolving taxonomic names to ids, looking up higher classification ranks of given species, or returning a list of all species below a given rank. These tasks are particularly common when synthesizing data across large species assemblies, such as combining occurrence records with trait records. 
 
-Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines.  Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. `taxald` creates a *local* database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.  
+Existing approaches to these problems typically rely on web APIs, which can make them impractical for work with large numbers of species or in more complex pipelines.  Queries and returned formats also differ across the different taxonomic authorities, making tasks that query multiple authorities particularly complex. `taxadb` creates a *local* database of most readily available taxonomic authorities, each of which is transformed into consistent, standard, and researcher-friendly tabular formats.  
 
 
 ## Install and initial setup
@@ -29,14 +29,14 @@ Existing approaches to these problems typically rely on web APIs, which can make
 To get started, install the development version directly from GitHub:
 
 ```{r eval=FALSE}
-devtools::install_github("cboettig/taxald")
+devtools::install_github("cboettig/taxadb")
 ```
 
 
-Before we can use most `taxald` functions, we need to do a one-time installation of the database `taxald` uses for almost all commands.  This can take a while to run, but needs only be done once.  The database is installed on your local hard-disk and will persist between R sessions.  By default, the database will be installed in your user's application data directory, as detected by the `rappdirs` package.  (Set a custom location instead using `dbdir` argument.)
+Before we can use most `taxadb` functions, we need to do a one-time installation of the database `taxadb` uses for almost all commands.  This can take a while to run, but needs only be done once.  The database is installed on your local hard-disk and will persist between R sessions.  By default, the database will be installed in your user's application data directory, as detected by the `rappdirs` package.  (Set a custom location instead using `dbdir` argument.)
 
 ```{r }
-library(taxald)
+library(taxadb)
 td_create()
 ```
 
@@ -55,11 +55,17 @@ descendants(name = "Aves", rank = "class")
 
 ## Learn More
 
-### [An introduction to taxald](https://cboettig.github.io/taxald/articles/articles/taxald.html) 
+### [An introduction to taxadb](https://cboettig.github.io/taxadb/articles/articles/taxadb.html) 
 
-The [taxald introduction](https://cboettig.github.io/taxald/articles/articles/taxald.html) 
-provides an overview showing how `taxald` functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.  
+The [taxadb introduction](https://cboettig.github.io/taxadb/articles/articles/taxadb.html) 
+provides an overview showing how `taxadb` functions can help us synthesize data across a given list of species by resolving synonyms and identifiers.  
 
-### [taxald schemas](https://cboettig.github.io/taxald/articles/articles/schema.html)
+### [taxadb schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html)
 
-See the [schemas](https://cboettig.github.io/taxald/articles/articles/schema.html) vignette for an overview of the underlying tables used by `taxald` functions, and more about the different authorities accessed by taxald.  
+See the [schemas](https://cboettig.github.io/taxadb/articles/articles/schema.html) vignette for an overview of the underlying tables used by `taxadb` functions, and more about the different authorities accessed by taxadb.  
+
+
+```{r include=FALSE}
+taxadb:::td_disconnect()
+```
+


### PR DESCRIPTION
@karinorman Just migrating the package name over to `taxadb`, which is probably more accurate / suggestive description of the scope.  

may attempt a separate package focused on a RDF triplestore instead of a standard SQL database like we have here using the `taxald` moniker (RDF ~ semantic data ~ [linked data](https://en.wikipedia.org/wiki/Linked_data)).  That might crash and burn but could be fun. 